### PR TITLE
feat(backend): add Club and Membership models

### DIFF
--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -1,0 +1,7 @@
+class Club < ApplicationRecord
+  belongs_to :created_by, class_name: "User"
+  has_many :memberships, dependent: :destroy
+  has_many :members, through: :memberships, source: :user
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,9 @@
+class Membership < ApplicationRecord
+  belongs_to :user
+  belongs_to :club
+
+  enum :role, { owner: "owner", member: "member" }
+
+  validates :role, presence: true
+  validates :user_id, uniqueness: { scope: :club_id }
+end

--- a/db/migrate/20260418093455_create_clubs.rb
+++ b/db/migrate/20260418093455_create_clubs.rb
@@ -1,0 +1,12 @@
+class CreateClubs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :clubs do |t|
+      t.string :name
+      t.text :description
+      t.references :created_by, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+    add_index :clubs, :name, unique: true
+  end
+end

--- a/db/migrate/20260418093648_create_memberships.rb
+++ b/db/migrate/20260418093648_create_memberships.rb
@@ -1,0 +1,13 @@
+class CreateMemberships < ActiveRecord::Migration[8.1]
+  def change
+    create_table :memberships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :club, null: false, foreign_key: true
+      t.string :role, null: false
+
+      t.timestamps
+    end
+
+    add_index :memberships, [ :user_id, :club_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_084001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_18_093648) do
+  create_table "clubs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "created_by_id", null: false
+    t.text "description"
+    t.string "name"
+    t.datetime "updated_at", null: false
+    t.index ["created_by_id"], name: "index_clubs_on_created_by_id"
+    t.index ["name"], name: "index_clubs_on_name", unique: true
+  end
+
+  create_table "memberships", force: :cascade do |t|
+    t.integer "club_id", null: false
+    t.datetime "created_at", null: false
+    t.string "role", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["club_id"], name: "index_memberships_on_club_id"
+    t.index ["user_id", "club_id"], name: "index_memberships_on_user_id_and_club_id", unique: true
+    t.index ["user_id"], name: "index_memberships_on_user_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "ip_address"
@@ -28,5 +49,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_18_084001) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "clubs", "users", column: "created_by_id"
+  add_foreign_key "memberships", "clubs"
+  add_foreign_key "memberships", "users"
   add_foreign_key "sessions", "users"
 end

--- a/test/fixtures/clubs.yml
+++ b/test/fixtures/clubs.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: ClubOne
+  description: ClubOne description
+  created_by: one
+
+two:
+  name: ClubTwo
+  description: ClubTwo description
+  created_by: two

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
   user: one
   club: one
@@ -7,5 +5,5 @@ one:
 
 two:
   user: two
-  club: two
+  club: one
   role: "member"

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  club: one
+  role: "owner"
+
+two:
+  user: two
+  club: two
+  role: "member"

--- a/test/models/club_test.rb
+++ b/test/models/club_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class ClubTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @club = clubs(:one)
+  end
+
+  test "is valid with valid attributes" do
+    assert @club.valid?
+  end
+
+  test "is invalid without a name" do
+    @club.name = nil
+    assert_not @club.valid?
+  end
+
+  test "is invalid with a duplicate name" do
+    duplicate = Club.new(name: @club.name, created_by: @user)
+    assert_not duplicate.valid?
+  end
+
+  test "has many memberships" do
+    assert_respond_to @club, :memberships
+  end
+
+  test "has many members through memberships" do
+    assert_respond_to @club, :members
+  end
+end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class MembershipTest < ActiveSupport::TestCase
+  setup do
+    @membership = memberships(:one)
+  end
+
+  test "is valid with valid attributes" do
+    assert @membership.valid?
+  end
+
+  test "is invalid without a role" do
+    @membership.role = nil
+    assert_not @membership.valid?
+  end
+
+  test "is invalid with a duplicate user and club combination" do
+    duplicate = Membership.new(
+      user: @membership.user,
+      club: @membership.club,
+      role: "member"
+    )
+    assert_not duplicate.valid?
+  end
+
+  test "owner role is valid" do
+    @membership.role = "owner"
+    assert @membership.valid?
+  end
+
+  test "member role is valid" do
+    @membership.role = "member"
+    assert @membership.valid?
+  end
+end


### PR DESCRIPTION
- Club and Membership models created with required fields per ADR-002
- Roles defined as enum (owner, member)
- Validations in place for uniqueness and required fields, with model tests
- Foreign key on Club.created_by explicitly points to users table
- Unique index on memberships (user_id, club_id)
- Fixed generated fixtures to respect clubs.name uniqueness constraint

Closes #7 