### PR TITLE
chore: run db:seed as part of bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,6 +22,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
+  system! "bin/rails db:seed"
   system! "bin/rails db:reset" if ARGV.include?("--reset")
 
   puts "\n== Removing old logs and tempfiles =="


### PR DESCRIPTION
- Seeds were not being run during setup
- Added db:seed after db:prepare so bin/setup gives a fully populated local environment out of the box
- Closes acceptance criteria on feat(backend): seed script for local dev

