### PR TITLE
chore(ci): skip CI on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
   push:
     branches: [main]
 


### PR DESCRIPTION
Adds `paths-ignore` section to `on:pull_request` workflow trigger