### PR TITLE
feat(backend): club CRUD with Turbo-powered list and detail views

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -1,0 +1,11 @@
+---
+EnableDefaultLinters: true
+linters:
+  ErbSafety:
+    enabled: true
+    better_html_config: .better-html.yml
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "erb_lint", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,13 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
+    better_html (2.2.0)
+      actionview (>= 7.0)
+      activesupport (>= 7.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (4.1.1)
     bindex (0.8.1)
     bootsnap (1.23.0)
@@ -113,6 +120,13 @@ GEM
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.3)
+    erb_lint (0.9.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.1)
     et-orbi (1.4.0)
       tzinfo
@@ -317,6 +331,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -399,6 +414,7 @@ DEPENDENCIES
   capybara
   debug
   dockerfile-rails (>= 1.7)
+  erb_lint
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
@@ -436,6 +452,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
+  better_html (2.2.0) sha256=e68ab66ab09696b708333bbf35e8aa3c107500ba7892f528e2111624bdd8cf76
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
@@ -453,6 +470,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   erb (6.0.3) sha256=e43685a8a0a0ea6a924871b2162e8953ef73147ce46b75b36d1f6774fd286e91
+  erb_lint (0.9.0) sha256=dfb5e40ad839e8d1f0d56ca85ec9a7ac4c9cd966ec281138282f35b323ca7c31
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
@@ -534,6 +552,7 @@ CHECKSUMS
   rubyzip (3.2.2) sha256=c0ed99385f0625415c8f05bcae33fe649ed2952894a95ff8b08f26ca57ea5b3c
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
+  smart_properties (1.17.0) sha256=f9323f8122e932341756ddec8e0ac9ec6e238408a7661508be99439ca6d6384b
   solid_cable (3.0.12) sha256=a168a54731a455d5627af48d8441ea3b554b8c1f6e6cd6074109de493e6b0460
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   solid_queue (1.4.0) sha256=e6a18d196f0b27cb6e3c77c5b31258b05fb634f8ed64fb1866ed164047216c2a

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -13,7 +13,7 @@ class ClubsController < ApplicationController
 
   def show
     @memberships = @club.memberships.includes(:user)
-    @club_owner = current_user_club_owner?(@club)
+    @club_owner = @club.owned_by?(Current.user)
   end
 
   def edit
@@ -64,11 +64,7 @@ class ClubsController < ApplicationController
     end
 
     def require_club_owner!
-      head :forbidden unless current_user_club_owner?(@club)
-    end
-
-    def current_user_club_owner?(club)
-      club.memberships.find_by(user_id: Current.user.id)&.owner?
+      head :forbidden unless @club.owned_by?(Current.user)
     end
 
     def clubs_for_current_user

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -1,0 +1,79 @@
+class ClubsController < ApplicationController
+  before_action :club_turbo_frames_guard, only: [ :new, :create ]
+  before_action :set_club, only: [ :show, :edit, :update, :destroy ]
+  before_action :require_club_owner!, only: [ :edit, :update, :destroy ]
+
+  def index
+    @clubs = clubs_for_current_user
+  end
+
+  def new
+    @club = Club.new
+  end
+
+  def show
+    @memberships = @club.memberships.includes(:user)
+    @club_owner = current_user_club_owner?(@club)
+  end
+
+  def edit
+  end
+
+  def update
+    if @club.update(club_params)
+      redirect_to club_path(@club)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @club.destroy!
+    redirect_to clubs_path, status: :see_other
+  end
+
+  def create
+    @club = Club.new(club_params.merge(created_by: Current.user))
+
+    ActiveRecord::Base.transaction do
+      @club.save!
+      @club.memberships.create!(user: Current.user, role: :owner)
+    end
+
+    @clubs = clubs_for_current_user
+    render :index
+  rescue ActiveRecord::RecordInvalid => error
+    unless error.record.equal?(@club)
+      @club.errors.add(:base, error.record.errors.full_messages.to_sentence)
+    end
+
+    render :new, status: :unprocessable_entity
+  end
+
+  private
+    def club_params
+      params.expect(club: [ :name, :description ])
+    end
+
+    def club_turbo_frames_guard
+      redirect_to clubs_path unless turbo_frame_request?
+    end
+
+    def set_club
+      @club = clubs_for_current_user.find(params[:id])
+    end
+
+    def require_club_owner!
+      head :forbidden unless current_user_club_owner?(@club)
+    end
+
+    def current_user_club_owner?(club)
+      club.memberships.find_by(user_id: Current.user.id)&.owner?
+    end
+
+    def clubs_for_current_user
+      Club.joins(:memberships)
+        .where(memberships: { user_id: Current.user.id })
+        .distinct
+    end
+end

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -4,4 +4,8 @@ class Club < ApplicationRecord
   has_many :members, through: :memberships, source: :user
 
   validates :name, presence: true, uniqueness: true
+
+  def owned_by?(user)
+    memberships.find_by(user_id: user.id)&.owner?
+  end
 end

--- a/app/views/clubs/edit.html.erb
+++ b/app/views/clubs/edit.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag "club_details_#{@club.id}" do %>
+  <%= form_with model: @club do |form| %>
+    <% if @club.errors.any? %>
+      <div>
+        <p><%= pluralize(@club.errors.count, "error") %> prevented this club from being updated:</p>
+        <ul>
+          <% @club.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <p>
+      <%= form.label :name %><br>
+      <%= form.text_field :name %>
+    </p>
+
+    <p>
+      <%= form.label :description %><br>
+      <%= form.text_area :description %>
+    </p>
+
+    <p>
+      <%= form.submit "Update Club" %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -1,0 +1,15 @@
+<h1>Your Clubs</h1>
+
+<%= turbo_frame_tag "clubs_list" do %>
+  <% if @clubs.any? %>
+    <ul>
+        <% @clubs.each do |club| %>
+          <li><%= link_to club.name, club_path(club), data: { turbo_frame: "_top" } %></li>
+        <% end %>
+    </ul>
+  <% else %>
+    <p>You aren't a member of any clubs yet</p>
+  <% end %>
+
+  <p><%= link_to "New Club", new_club_path %></p>
+<% end %>

--- a/app/views/clubs/new.html.erb
+++ b/app/views/clubs/new.html.erb
@@ -1,0 +1,30 @@
+<%= turbo_frame_tag "clubs_list" do %>
+  <h2>New Club</h2>
+
+  <% if @club.errors.any? %>
+    <div>
+      <p><%= pluralize(@club.errors.count, "error") %> prevented this club from being created:</p>
+      <ul>
+        <% @club.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= form_with model: @club do |form| %>
+    <p>
+      <%= form.label :name %><br>
+      <%= form.text_field :name %>
+    </p>
+
+    <p>
+      <%= form.label :description %><br>
+      <%= form.text_area :description %>
+    </p>
+
+    <p>
+      <%= form.submit "Create Club" %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -1,0 +1,20 @@
+<%= turbo_frame_tag "club_details_#{@club.id}" do %>
+  <h1><%= @club.name %></h1>
+  <p><%= @club.description.presence || "No description provided." %></p>
+
+  <h2>Members</h2>
+  <ul>
+    <% @memberships.each do |membership| %>
+      <li><%= membership.user.email_address %></li>
+    <% end %>
+  </ul>
+
+  <p>Invite link placeholder</p>
+
+  <% if @club_owner %>
+    <p><%= link_to "Edit Club", edit_club_path(@club) %></p>
+    <p><%= link_to "Delete Club", club_path(@club), data: { turbo_method: :delete, turbo_confirm: "Delete this club?", turbo_frame: "_top" } %></p>
+  <% end %>
+
+  <p><%= link_to "Back to Clubs", clubs_path, data: { turbo_frame: "_top" } %></p>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,12 @@
   </head>
 
   <body>
+    <% if authenticated? %>
+      <header>
+        <%= link_to "Sign out", session_path, data: { turbo_method: :delete } %>
+      </header>
+    <% end %>
+
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
+  resources :clubs, only: %i[ index show new create edit update destroy ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -12,7 +13,7 @@ Rails.application.routes.draw do
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   # Defines the root path route ("/")
-  root "sessions#new"
+  root "clubs#index"
 
   resource :registration, only: %i[ new create ]
 end

--- a/test/controllers/clubs_controller_test.rb
+++ b/test/controllers/clubs_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class ClubsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:one)
+    @non_owner = users(:two)
+    @club = clubs(:one)
+  end
+
+  test "owner can edit their club" do
+    sign_in_as(@owner)
+
+    get edit_club_path(@club)
+    assert_response :success
+
+    patch club_path(@club), params: { club: { name: "Updated Club Name", description: "Updated description" } }
+    assert_redirected_to club_path(@club)
+    assert_equal "Updated Club Name", @club.reload.name
+  end
+
+  test "owner can delete their club" do
+    sign_in_as(@owner)
+
+    assert_difference("Club.count", -1) do
+      delete club_path(@club)
+    end
+
+    assert_redirected_to clubs_path
+  end
+
+  test "non-owner gets 403 on edit" do
+    sign_in_as(@non_owner)
+
+    get edit_club_path(@club)
+    assert_response :forbidden
+  end
+
+  test "non-owner gets 403 on update" do
+    sign_in_as(@non_owner)
+
+    patch club_path(@club), params: { club: { name: "Should Not Update" } }
+    assert_response :forbidden
+  end
+
+  test "non-owner gets 403 on destroy" do
+    sign_in_as(@non_owner)
+
+    delete club_path(@club)
+    assert_response :forbidden
+  end
+
+  test "unauthenticated user is redirected on edit" do
+    get edit_club_path(@club)
+
+    assert_redirected_to new_session_path
+  end
+
+  test "unauthenticated user is redirected on update" do
+    patch club_path(@club), params: { club: { name: "Nope" } }
+
+    assert_redirected_to new_session_path
+  end
+
+  test "unauthenticated user is redirected on destroy" do
+    delete club_path(@club)
+
+    assert_redirected_to new_session_path
+  end
+end

--- a/test/models/club_test.rb
+++ b/test/models/club_test.rb
@@ -27,4 +27,12 @@ class ClubTest < ActiveSupport::TestCase
   test "has many members through memberships" do
     assert_respond_to @club, :members
   end
+
+  test "owned_by? returns true for owner" do
+    assert @club.owned_by?(users(:one))
+  end
+
+  test "owned_by? returns false for non-owner member" do
+    assert_not @club.owned_by?(users(:two))
+  end
 end


### PR DESCRIPTION
- Club index scoped to current user's memberships
- Create form loads inside Turbo Frame, updates list on success
- Edit form loads in-place on club detail page via named Turbo Frame
- Owner-only edit, update, destroy enforced via before_action
- Transaction wraps club save and owner membership creation
- Guard redirects non-frame requests for new and create to clubs index
- erb linting added via gem

Closes #21 #22 