### PR TITLE
feat(backend): signed invite links for joining a club

### DIFF
--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -14,6 +14,7 @@ class ClubsController < ApplicationController
   def show
     @memberships = @club.memberships.includes(:user)
     @club_owner = @club.owned_by?(Current.user)
+    @invite_token = @club.signed_id(expires_in: 1.week)
   end
 
   def edit

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,0 +1,24 @@
+class InvitesController < ApplicationController
+  def show
+    @club = Club.find_signed(params[:signed_id])
+
+    if @club.nil?
+      render "invites/invalid", status: :not_found
+      return
+    end
+
+    if @club.memberships.exists?(user: Current.user)
+      redirect_to club_path(@club), alert: "You're already a member of this club."
+      return
+    end
+
+    @club.memberships.create!(user: Current.user, role: :member)
+    redirect_to club_path(@club), notice: "You've joined #{@club.name}."
+  end
+
+  private
+    def request_authentication
+      flash[:alert] = "Please sign in to accept the invite."
+      super
+    end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,9 @@ class SessionsController < ApplicationController
 
   def create
     if user = User.authenticate_by(params.permit(:email_address, :password))
+      return_to = session[:return_to_after_authenticating]
       reset_session
+      session[:return_to_after_authenticating] = return_to if return_to
       start_new_session_for user
       redirect_to after_authentication_url
     else

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -9,9 +9,8 @@
     <% end %>
   </ul>
 
-  <p>Invite link placeholder</p>
-
   <% if @club_owner %>
+    <p>Invite link: <%= invite_url(signed_id: @invite_token) %></p>
     <p><%= link_to "Edit Club", edit_club_path(@club) %></p>
     <p><%= link_to "Delete Club", club_path(@club), data: { turbo_method: :delete, turbo_confirm: "Delete this club?", turbo_frame: "_top" } %></p>
   <% end %>

--- a/app/views/invites/invalid.html.erb
+++ b/app/views/invites/invalid.html.erb
@@ -1,0 +1,2 @@
+<h1>Invite Link Invalid</h1>
+<p>This invite link has expired or is invalid. Please ask the club owner for a new one.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,8 +26,13 @@
   <body>
     <% if authenticated? %>
       <header>
+        <span>Signed in as <%= Current.user.email_address %></span>
         <%= link_to "Sign out", session_path, data: { turbo_method: :delete } %>
       </header>
+    <% end %>
+
+    <% flash.each do |type, message| %>
+      <p><%= message %></p>
     <% end %>
 
     <%= yield %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,6 +1,3 @@
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
-<%= tag.div(flash[:notice], style: "color:green") if flash[:notice] %>
-
 <%= form_with url: session_path do |form| %>
   <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
   <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72 %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
   resources :clubs, only: %i[ index show new create edit update destroy ]
+  get "/invites/:signed_id", to: "invites#show", as: :invite
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/invites_controller_test.rb
+++ b/test/controllers/invites_controller_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class InvitesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user_one = users(:one)
+    @user_two = users(:two)
+    # club :two is owned by user :two; user :one has no membership in it
+    @club = clubs(:two)
+    @valid_token = @club.signed_id(expires_in: 1.week)
+  end
+
+  test "valid invite: member is added and redirected with notice" do
+    sign_in_as(@user_one)
+
+    assert_difference "@club.memberships.count", 1 do
+      get invite_path(signed_id: @valid_token)
+    end
+
+    assert_redirected_to club_path(@club)
+    follow_redirect!
+    assert_equal "You've joined #{@club.name}.", flash[:notice]
+  end
+
+  test "already a member: redirected with alert and no duplicate membership" do
+    # user :two is a member of club :one via fixtures
+    club_one = clubs(:one)
+    token = club_one.signed_id(expires_in: 1.week)
+    sign_in_as(@user_two)
+
+    assert_no_difference "club_one.memberships.count" do
+      get invite_path(signed_id: token)
+    end
+
+    assert_redirected_to club_path(club_one)
+    follow_redirect!
+    assert_equal "You're already a member of this club.", flash[:alert]
+  end
+
+  test "invalid token: renders invalid template with 404" do
+    sign_in_as(@user_one)
+    get invite_path(signed_id: "this-is-garbage")
+
+    assert_response :not_found
+    assert_select "h1", "Invite Link Invalid"
+  end
+
+  test "unauthenticated user: redirected to sign in with alert and return_to set" do
+    get invite_path(signed_id: @valid_token)
+
+    assert_redirected_to new_session_path
+    follow_redirect!
+    assert_equal "Please sign in to accept the invite.", flash[:alert]
+    assert_equal invite_url(signed_id: @valid_token), session[:return_to_after_authenticating]
+  end
+end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -70,6 +70,6 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
 
   private
     def assert_notice(text)
-      assert_select "div", /#{text}/
+      assert_select "p", /#{text}/
     end
 end


### PR DESCRIPTION
- Signed, expiring invite links via Club.signed_id (1-week expiry)
- InvitesController handles expired/invalid, already-a-member,
  and new member scenarios
- request_authentication overridden to show contextual flash before
  redirecting unauthenticated users to sign in
- return_to preserved across reset_session for post-login redirect
- Invite URL shown on club detail page to owners only
- Flash messages rendered globally in application layout

TESTS:
- Valid invite adds membership and redirects with notice
- Already a member redirects with alert, no duplicate membership created
- Invalid or expired token renders 404 with invalid template
- Unauthenticated user redirected to sign in with contextual flash and return_to set correctly