### PR TITLE
feat(backend): implement Stimulus copy invite button

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,20 @@
+// src/controllers/clipboard_controller.js
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["source", "button"];
+
+  copy() {
+    navigator.clipboard
+      .writeText(this.sourceTarget.textContent)
+      .then(() => {
+        this.buttonTarget.textContent = "Copied!";
+        setTimeout(() => {
+          this.buttonTarget.textContent = "Copy Invite Link";
+        }, 2000);
+      })
+      .catch((err) => {
+        console.error("Failed to copy text: ", err);
+      });
+  }
+}

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -10,7 +10,10 @@
   </ul>
 
   <% if @club_owner %>
-    <p>Invite link: <%= invite_url(signed_id: @invite_token) %></p>
+    <div data-controller="clipboard">
+      <p>Invite link: <span data-clipboard-target="source"><%= invite_url(signed_id: @invite_token) %></span></p>
+      <button data-clipboard-target="button" data-action="clipboard#copy">Copy to Clipboard</button>
+    </div>
     <p><%= link_to "Edit Club", edit_club_path(@club) %></p>
     <p><%= link_to "Delete Club", club_path(@club), data: { turbo_method: :delete, turbo_confirm: "Delete this club?", turbo_frame: "_top" } %></p>
   <% end %>


### PR DESCRIPTION
Adds a copy invite link button using Stimulus.

Leans on the docs examples for similar functionality, while expanding through targeted updates to reflect copy process state.

Closes #26 