### PR TITLE
feat(backend): Book model with Google Books fields

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,0 +1,4 @@
+class Book < ApplicationRecord
+  validates :title, presence: true
+  validates :google_books_id, uniqueness: true, allow_nil: true
+end

--- a/db/migrate/20260419171237_create_books.rb
+++ b/db/migrate/20260419171237_create_books.rb
@@ -1,0 +1,17 @@
+class CreateBooks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :books do |t|
+      t.string :title, null: false
+      t.string :authors
+      t.string :isbn
+      t.string :google_books_id
+      t.text :description
+      t.string :cover_url
+      t.string :publisher
+      t.string :published_date
+
+      t.timestamps
+    end
+    add_index :books, :google_books_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_18_093648) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_19_171237) do
+  create_table "books", force: :cascade do |t|
+    t.string "authors"
+    t.string "cover_url"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "google_books_id"
+    t.string "isbn"
+    t.string "published_date"
+    t.string "publisher"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["google_books_id"], name: "index_books_on_google_books_id", unique: true
+  end
+
   create_table "clubs", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "created_by_id", null: false

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -1,0 +1,21 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+oathbringer:
+  title: "Oathbringer"
+  authors: "Brandon Sanderson"
+  isbn: "9780575093355"
+  google_books_id: "1xfwCgAAQBAJ"
+  description: "The third volume of the Stormlight Archive series."
+  cover_url: "https://www.google.co.uk/books/content?id=1xfwCgAAQBAJ&printsec=frontcover&img=1&zoom=1"
+  publisher: "Tor Books"
+  published_date: "2017"
+
+handmaids_tale:
+  title: "The Handmaid's Tale"
+  authors: "Margaret Atwood"
+  isbn: "9781784708238"
+  google_books_id: "o79lk6nTsRgC"
+  description: "A dystopian novel set in the near-future theocratic republic of Gilead."
+  cover_url: "https://www.google.co.uk/books/content?id=o79lk6nTsRgC&printsec=frontcover&img=1&zoom=1"
+  publisher: "Anchor Books"
+  published_date: "1998"

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class BookTest < ActiveSupport::TestCase
+  test "is valid with required fields" do
+    book = books(:oathbringer)
+    assert book.valid?
+  end
+
+  test "is invalid without a title" do
+    book = books(:oathbringer)
+    book.title = nil
+    assert_not book.valid?
+    assert_includes book.errors[:title], "can't be blank"
+  end
+
+  test "is invalid with a duplicate google_books_id" do
+    duplicate = books(:oathbringer).dup
+    duplicate.isbn = nil
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:google_books_id], "has already been taken"
+  end
+
+  test "is valid with a nil google_books_id" do
+    book = books(:oathbringer)
+    book.google_books_id = nil
+    assert book.valid?
+  end
+end


### PR DESCRIPTION
Adds Book model with title, authors, isbn, google_books_id, description, cover_url, publisher, and published_date. Unique index on google_books_id. Validates title presence and google_books_id uniqueness (nil allowed).

Fixtures use verified Google Books data: Oathbringer and The Handmaid's Tale.

Closes #27 