### PR TITLE
feat(backend): live search-as-you-type book lookup via Turbo Streams

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,0 +1,21 @@
+class BooksController < ApplicationController
+  def search
+    @query = params[:query].to_s.strip
+
+    if @query.present?
+      begin
+        @results = BookLookupService.search(@query)
+      rescue RuntimeError
+        @error = true
+        @results = []
+      end
+    else
+      @results = []
+    end
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
+  end
+end

--- a/app/javascript/controllers/book_search_controller.js
+++ b/app/javascript/controllers/book_search_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["input"];
+
+  debouncedSubmit() {
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => {
+      this.element.requestSubmit();
+    }, 300);
+  }
+}

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -1,0 +1,17 @@
+<% if @error %>
+  <p>Something went wrong. Please try again.</p>
+<% elsif @results.empty? && @query.present? %>
+  <p>No books found for "<%= @query %>".</p>
+<% else %>
+  <% @results.each do |book| %>
+    <div>
+      <% if book.cover_url.present? %>
+        <%= image_tag book.cover_url, alt: book.title %>
+      <% else %>
+        <div>No cover available</div>
+      <% end %>
+      <p><strong><%= book.title %></strong></p>
+      <p><%= book.authors %></p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/books/search.html.erb
+++ b/app/views/books/search.html.erb
@@ -1,0 +1,13 @@
+<h1>Search for a book</h1>
+
+<%= form_with url: search_books_path, method: :get, data: { controller: "book-search", turbo_stream: true } do |f| %>
+  <%= f.text_field :query,
+      value: @query,
+      placeholder: "Title or author...",
+      data: { book_search_target: "input", action: "input->book-search#debouncedSubmit" } %>
+  <%= f.submit "Search" %>
+<% end %>
+
+<div id="book-results">
+  <%= render "results" %>
+</div>

--- a/app/views/books/search.turbo_stream.erb
+++ b/app/views/books/search.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "book-results" do %>
+  <%= render "results" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,21 @@
 Rails.application.routes.draw do
+  # Auth
   resource :session
+  resource :registration, only: %i[new create]
   resources :passwords, param: :token
-  resources :clubs, only: %i[ index show new create edit update destroy ]
-  get "/invites/:signed_id", to: "invites#show", as: :invite
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
+  # Core app
   root "clubs#index"
 
-  resource :registration, only: %i[ new create ]
+  resources :clubs, only: %i[index show new create edit update destroy]
+  get "/invites/:signed_id", to: "invites#show", as: :invite
+
+  resources :books, only: [] do
+    collection do
+      get :search
+    end
+  end
+
+  # Infrastructure
+  get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class BooksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:one)
+  end
+
+  test "search returns turbo stream when query is present" do
+    sign_in_as(@owner)
+
+    get search_books_path,
+        params: { query: "Oathbringer" },
+        headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.content_type.split(";").first
+  end
+end


### PR DESCRIPTION
Adds GET /books/search route, BooksController#search action, and supporting views. Calls BookLookupService.search with the query param and renders results via a Turbo Stream updating #book-results in place.

Controller responds to both format.html (full page, progressive enhancement baseline) and format.turbo_stream (partial update). Error state and empty results state handled in the shared _results partial.

Form uses data-turbo-stream: true to ensure Turbo sends the correct Accept header on GET form submissions. turbo_stream.update used rather than replace to preserve the #book-results target element across successive responses.

Stimulus book-search controller debounces input at 300ms and calls requestSubmit() so Turbo intercepts the submission. Plain submit() bypasses Turbo and causes a full-page reload.

Routes reorganised: auth routes grouped at top, books resource uses collection route for search, PWA comments removed.

Request test confirms search_books_path returns 200 with turbo-stream content type. Test requires authenticated session.