### PR TITLE
feat(backend): add page_count to Book and BookLookupService::Result

### DIFF
--- a/app/services/book_lookup_service.rb
+++ b/app/services/book_lookup_service.rb
@@ -3,7 +3,7 @@ class BookLookupService
 
   Result = Data.define(
     :google_books_id, :title, :authors, :isbn,
-    :description, :cover_url, :publisher, :published_date
+    :description, :cover_url, :publisher, :published_date, :page_count
   ) do
     def cover_image_url
       cover_url
@@ -51,7 +51,8 @@ class BookLookupService
         description: volume_info["description"],
         cover_url: volume_info.dig("imageLinks", "thumbnail"),
         publisher: volume_info["publisher"],
-        published_date: volume_info["publishedDate"]
+        published_date: volume_info["publishedDate"],
+        page_count: volume_info["pageCount"]
       )
     end
 

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -12,6 +12,10 @@
       <% end %>
       <p><strong><%= book.title %></strong></p>
       <p><%= book.authors %></p>
+      <%# page_count can be nil or 0 from Google Books — both treated as absent %>
+      <% if book.page_count.presence&.positive? %>
+        <p><%= book.page_count %> pages</p>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/db/migrate/20260420215505_add_page_count_to_books.rb
+++ b/db/migrate/20260420215505_add_page_count_to_books.rb
@@ -1,0 +1,5 @@
+class AddPageCountToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :page_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_19_183911) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_215505) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -46,6 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_19_183911) do
     t.text "description"
     t.string "google_books_id"
     t.string "isbn"
+    t.integer "page_count"
     t.string "published_date"
     t.string "publisher"
     t.string "title"

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -9,6 +9,7 @@ oathbringer:
   cover_url: "http://books.google.com/books/content?id=VsT3DQAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
   publisher: "Tor Books"
   published_date: "2017-11-14"
+  page_count: 1531
 
 handmaids_tale:
   title: "The Handmaid's Tale"
@@ -19,3 +20,4 @@ handmaids_tale:
   cover_url: "http://books.google.com/books/content?id=ECuBswEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api"
   publisher: "Vintage"
   published_date: "2017"
+  page_count: 322

--- a/test/services/book_lookup_service_test.rb
+++ b/test/services/book_lookup_service_test.rb
@@ -11,7 +11,8 @@ class BookLookupServiceTest < ActiveSupport::TestCase
       ],
       "imageLinks" => { "thumbnail" => "https://books.google.com/thumbnail.jpg" },
       "publisher" => "Tor Books",
-      "publishedDate" => "2017"
+      "publishedDate" => "2017",
+      "pageCount" => 1232
     }
   }.freeze
 
@@ -36,6 +37,7 @@ class BookLookupServiceTest < ActiveSupport::TestCase
     assert_equal "Oathbringer", result.title
     assert_equal "Brandon Sanderson", result.authors
     assert_equal "9780575093355", result.isbn
+    assert_equal 1232, result.page_count
   end
 
   test "search returns empty array when no items" do


### PR DESCRIPTION
Adds page_count to the data retrieved from the GoogleBooks API and presented in results.
    
Ensures nil or 0 values are handled correctly.

Closes #70 