### PR TITLE
feat(backend): add Cycle model with state transitions

### DIFF
--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -2,10 +2,15 @@ class Club < ApplicationRecord
   belongs_to :created_by, class_name: "User"
   has_many :memberships, dependent: :destroy
   has_many :members, through: :memberships, source: :user
+  has_many :cycles, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 
   def owned_by?(user)
     memberships.find_by(user_id: user.id)&.owner?
+  end
+
+  def current_cycle
+    cycles.find_by(state: [ :nominating, :voting, :reading ])
   end
 end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,0 +1,28 @@
+class Cycle < ApplicationRecord
+  belongs_to :club
+
+  enum :state, { nominating: "nominating", voting: "voting", reading: "reading", complete: "complete" }
+
+  validates :state, presence: true
+
+  validates :club_id, uniqueness: {
+    conditions: -> { where.not(state: :complete) },
+    message: "can only have one active cycle at a time"
+  }
+
+  # Transition methods - each raises on invalid transition
+  def advance_to_voting!
+    raise "Cannot advance to voting from #{state}" unless nominating?
+    update!(state: :voting)
+  end
+
+  def advance_to_reading!
+    raise "Cannot advance to reading from #{state}" unless voting?
+    update!(state: :reading)
+  end
+
+  def complete!
+    raise "Cannot complete from #{state}" unless reading?
+    update!(state: :complete)
+  end
+end

--- a/db/migrate/20260420230000_create_cycles.rb
+++ b/db/migrate/20260420230000_create_cycles.rb
@@ -1,0 +1,13 @@
+class CreateCycles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :cycles do |t|
+      t.references :club, null: false, foreign_key: true
+      t.string :state, default: "nominating", null: false
+
+      t.timestamps
+    end
+
+    # Partial unique index: only one active (non-complete) cycle per club
+    add_index :cycles, :club_id, unique: true, where: "state != 'complete'", name: "index_cycles_on_club_id_where_state_not_complete"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_215505) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_20_230000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -64,6 +64,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_215505) do
     t.index ["name"], name: "index_clubs_on_name", unique: true
   end
 
+  create_table "cycles", force: :cascade do |t|
+    t.integer "club_id", null: false
+    t.datetime "created_at", null: false
+    t.string "state", default: "nominating", null: false
+    t.datetime "updated_at", null: false
+    t.index ["club_id"], name: "index_cycles_on_club_id"
+    t.index ["club_id"], name: "index_cycles_on_club_id_where_state_not_complete", unique: true, where: "state != 'complete'"
+  end
+
   create_table "memberships", force: :cascade do |t|
     t.integer "club_id", null: false
     t.datetime "created_at", null: false
@@ -93,6 +102,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_215505) do
   end
 
   add_foreign_key "clubs", "users", column: "created_by_id"
+  add_foreign_key "cycles", "clubs"
   add_foreign_key "memberships", "clubs"
   add_foreign_key "memberships", "users"
   add_foreign_key "sessions", "users"

--- a/test/fixtures/cycles.yml
+++ b/test/fixtures/cycles.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  club: one
+  state: nominating
+
+two:
+  club: two
+  state: voting

--- a/test/models/club_test.rb
+++ b/test/models/club_test.rb
@@ -28,6 +28,20 @@ class ClubTest < ActiveSupport::TestCase
     assert_respond_to @club, :members
   end
 
+  test "has many cycles" do
+    assert_respond_to @club, :cycles
+  end
+
+  test "current_cycle returns the active cycle" do
+    active_cycle = cycles(:one)
+    assert_equal active_cycle, @club.current_cycle
+  end
+
+  test "current_cycle returns nil when no active cycles exist" do
+    @club.cycles.update_all(state: :complete)
+    assert_nil @club.current_cycle
+  end
+
   test "owned_by? returns true for owner" do
     assert @club.owned_by?(users(:one))
   end

--- a/test/models/cycle_test.rb
+++ b/test/models/cycle_test.rb
@@ -1,0 +1,117 @@
+require "test_helper"
+
+class CycleTest < ActiveSupport::TestCase
+  setup do
+    @club = clubs(:one)
+  end
+
+  # Valid creation tests
+  test "is valid with valid attributes" do
+    # Create a club without active cycles for this test
+    club_without_cycle = Club.create!(name: "Test Club", created_by: users(:one))
+    cycle = Cycle.new(club: club_without_cycle, state: "nominating")
+    assert cycle.valid?
+  end
+
+  test "has default state of nominating" do
+    club_without_cycle = Club.create!(name: "Test Club 2", created_by: users(:one))
+    cycle = Cycle.new(club: club_without_cycle)
+    assert_equal "nominating", cycle.state
+  end
+
+  test "is invalid without a club" do
+    cycle = Cycle.new(state: "nominating")
+    assert_not cycle.valid?
+  end
+
+  test "is invalid without a state" do
+    cycle = Cycle.new(club: @club, state: nil)
+    assert_not cycle.valid?
+  end
+
+  # State enum tests
+  test "has all valid state enums" do
+    assert_equal %w[nominating voting reading complete], Cycle.states.keys.map(&:to_s)
+  end
+
+  # Valid transitions
+  test "advance_to_voting! transitions from nominating to voting" do
+    cycle = cycles(:one)
+    assert_equal "nominating", cycle.state
+    cycle.advance_to_voting!
+    assert_equal "voting", cycle.reload.state
+  end
+
+  test "advance_to_reading! transitions from voting to reading" do
+    cycle = cycles(:one)
+    cycle.update!(state: :voting)
+    cycle.advance_to_reading!
+    assert_equal "reading", cycle.reload.state
+  end
+
+  test "complete! transitions from reading to complete" do
+    cycle = cycles(:one)
+    cycle.update!(state: :reading)
+    cycle.complete!
+    assert_equal "complete", cycle.reload.state
+  end
+
+  # Invalid transitions
+  test "advance_to_voting! raises when not in nominating state" do
+    cycle = cycles(:one)
+    cycle.update!(state: :voting)
+    assert_raises(RuntimeError) { cycle.advance_to_voting! }
+  end
+
+  test "advance_to_reading! raises when not in voting state" do
+    cycle = cycles(:one)
+    assert_raises(RuntimeError) { cycle.advance_to_reading! }
+  end
+
+  test "complete! raises when not in reading state" do
+    cycle = cycles(:one)
+    assert_raises(RuntimeError) { cycle.complete! }
+  end
+
+  # One active cycle per club constraint
+  test "is invalid when club already has an active cycle" do
+    existing_cycle = cycles(:one)
+    assert existing_cycle.valid?
+
+    new_cycle = Cycle.new(club: @club, state: "nominating")
+    assert_not new_cycle.valid?
+    assert new_cycle.errors.full_messages.join(", ").include?("only have one active cycle")
+  end
+
+  test "allows a new active cycle after existing cycle is complete" do
+    existing_cycle = cycles(:one)
+    existing_cycle.update!(state: :complete)
+
+    new_cycle = Cycle.new(club: @club, state: "nominating")
+    assert new_cycle.valid?
+  end
+
+  test "allows multiple complete cycles for a club" do
+    cycle1 = cycles(:one)
+    cycle1.update!(state: :complete)
+
+    cycle2 = @club.cycles.create!(state: "nominating")
+    cycle2.update!(state: :complete)
+
+    assert cycle1.complete?
+    assert cycle2.complete?
+  end
+
+  # Belongs to club
+  test "belongs to club" do
+    cycle = cycles(:one)
+    assert_equal @club, cycle.club
+  end
+
+  # Timestamps
+  test "has timestamps" do
+    cycle = cycles(:one)
+    assert_not_nil cycle.created_at
+    assert_not_nil cycle.updated_at
+  end
+end


### PR DESCRIPTION
- Cycle belongs to Club with four string enum states: nominating, voting, reading, complete
- Explicit transition methods raise on invalid transitions
- One active cycle per club enforced at model level (uniqueness validation with conditions) and DB level (partial unique index where state != 'complete')
- Club#current_cycle returns the single non-complete cycle or nil
- Full model test coverage: valid creation, all transitions, invalid transitions, one-active-cycle constraint