### PR TITLE
feat(backend): add Nomination model and BookFindOrCreateService

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,4 +1,6 @@
 class Book < ApplicationRecord
+  has_many :nominations, dependent: :restrict_with_error
+
   validates :title, presence: true
   validates :google_books_id, uniqueness: true, allow_nil: true
 

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,5 +1,6 @@
 class Cycle < ApplicationRecord
   belongs_to :club
+  has_many :nominations, dependent: :destroy
 
   enum :state, { nominating: "nominating", voting: "voting", reading: "reading", complete: "complete" }
 

--- a/app/models/nomination.rb
+++ b/app/models/nomination.rb
@@ -1,0 +1,8 @@
+class Nomination < ApplicationRecord
+  belongs_to :book
+  belongs_to :cycle
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :cycle_id }
+  validates :book_id, uniqueness: { scope: :cycle_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   validates :email_address, uniqueness: { case_sensitive: false }
 
   has_many :sessions, dependent: :destroy
+  has_many :nominations, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 end

--- a/app/services/book_find_or_create_service.rb
+++ b/app/services/book_find_or_create_service.rb
@@ -1,0 +1,30 @@
+class BookFindOrCreateService
+  class << self
+    def call(result)
+      if result.google_books_id.present?
+        existing_book = Book.find_by(google_books_id: result.google_books_id)
+        return existing_book if existing_book
+      end
+
+      book = Book.create!(book_attributes(result))
+      CacheCoverImageJob.perform_later(book.id)
+      book
+    end
+
+    private
+
+    def book_attributes(result)
+      {
+        google_books_id: result.google_books_id,
+        title: result.title,
+        authors: result.authors,
+        isbn: result.isbn,
+        description: result.description,
+        cover_url: result.cover_url,
+        publisher: result.publisher,
+        published_date: result.published_date,
+        page_count: result.page_count
+      }
+    end
+  end
+end

--- a/db/migrate/20260421000100_create_nominations.rb
+++ b/db/migrate/20260421000100_create_nominations.rb
@@ -1,0 +1,14 @@
+class CreateNominations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :nominations do |t|
+      t.references :book, null: false, foreign_key: true
+      t.references :cycle, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :nominations, [ :cycle_id, :user_id ], unique: true
+    add_index :nominations, [ :cycle_id, :book_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_20_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_000100) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -84,6 +84,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_230000) do
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
+  create_table "nominations", force: :cascade do |t|
+    t.integer "book_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "cycle_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["book_id"], name: "index_nominations_on_book_id"
+    t.index ["cycle_id", "book_id"], name: "index_nominations_on_cycle_id_and_book_id", unique: true
+    t.index ["cycle_id", "user_id"], name: "index_nominations_on_cycle_id_and_user_id", unique: true
+    t.index ["cycle_id"], name: "index_nominations_on_cycle_id"
+    t.index ["user_id"], name: "index_nominations_on_user_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "ip_address"
@@ -105,5 +118,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_20_230000) do
   add_foreign_key "cycles", "clubs"
   add_foreign_key "memberships", "clubs"
   add_foreign_key "memberships", "users"
+  add_foreign_key "nominations", "books"
+  add_foreign_key "nominations", "cycles"
+  add_foreign_key "nominations", "users"
   add_foreign_key "sessions", "users"
 end

--- a/test/fixtures/nominations.yml
+++ b/test/fixtures/nominations.yml
@@ -1,0 +1,9 @@
+one:
+  book: oathbringer
+  cycle: one
+  user: one
+
+two:
+  book: handmaids_tale
+  cycle: one
+  user: two

--- a/test/models/nomination_test.rb
+++ b/test/models/nomination_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class NominationTest < ActiveSupport::TestCase
+  test "is valid with valid associations" do
+    nomination = nominations(:one)
+
+    assert nomination.valid?
+  end
+
+  test "rejects duplicate nomination for same user and cycle" do
+    existing_nomination = nominations(:one)
+    duplicate = Nomination.new(
+      cycle: existing_nomination.cycle,
+      user: existing_nomination.user,
+      book: books(:handmaids_tale)
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:user_id], "has already been taken"
+  end
+
+  test "rejects duplicate book nomination in same cycle from different user" do
+    existing_nomination = nominations(:one)
+    duplicate = Nomination.new(
+      cycle: existing_nomination.cycle,
+      user: users(:two),
+      book: existing_nomination.book
+    )
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:book_id], "has already been taken"
+  end
+end

--- a/test/services/book_find_or_create_service_test.rb
+++ b/test/services/book_find_or_create_service_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class BookFindOrCreateServiceTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup do
+    clear_enqueued_jobs
+  end
+
+  test "finds existing book by google_books_id without dispatching cache job" do
+    existing_book = books(:oathbringer)
+    result = BookLookupService::Result.new(
+      google_books_id: existing_book.google_books_id,
+      title: "Different Title",
+      authors: "Different Author",
+      isbn: "0000000000000",
+      description: "Different description",
+      cover_url: "https://example.com/different.jpg",
+      publisher: "Different Publisher",
+      published_date: "2020-01-01",
+      page_count: 999
+    )
+
+    book = nil
+    assert_no_enqueued_jobs only: CacheCoverImageJob do
+      book = BookFindOrCreateService.call(result)
+    end
+
+    assert_equal existing_book.id, book.id
+    assert_equal "Oathbringer", book.title
+  end
+
+  test "creates new book and dispatches cache job" do
+    result = BookLookupService::Result.new(
+      google_books_id: "new_google_books_id_123",
+      title: "New Book",
+      authors: "A. Author",
+      isbn: "9780000000001",
+      description: "A description",
+      cover_url: "https://example.com/new-book.jpg",
+      publisher: "New Publisher",
+      published_date: "2026-04-20",
+      page_count: 250
+    )
+
+    created_book = nil
+    assert_enqueued_jobs 1, only: CacheCoverImageJob do
+      created_book = BookFindOrCreateService.call(result)
+    end
+
+    assert created_book.persisted?
+    assert_equal result.google_books_id, created_book.google_books_id
+
+    cache_job = enqueued_jobs.find { |job| job[:job] == CacheCoverImageJob }
+    assert_not_nil cache_job
+    assert_equal [ created_book.id ], cache_job[:args]
+  end
+end


### PR DESCRIPTION
- Nomination joins Book, Cycle, and User with belongs_to associations
- One nomination per user per cycle enforced at model and DB level (unique index on [cycle_id, user_id])
- One nomination per book per cycle enforced at model and DB level (unique index on [cycle_id, book_id])—added during implementation, not in original spec; prevents duplicate books in a cycle's nominations
- BookFindOrCreateService finds by google_books_id or creates from a BookLookupService::Result; dispatches CacheCoverImageJob on new books only
- Appropriate dependent options added: Book :restrict_with_error, User and Cycle :destroy
- Foreign keys on nominations.book_id, cycle_id, user_id
- Model and service tests covering both uniqueness constraints and both service paths (find vs create)

Closes #33 