### PR TITLE
feat(backend): nomination UI—search and add to current cycle

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,10 @@ class ApplicationController < ActionController::Base
 
   # Changes to the importmap will invalidate the etag for HTML responses
   stale_when_importmap_changes
+
+  before_action :set_user
+
+  def set_user
+    @user = User.find_by(id: session[:user_id])
+  end
 end

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -15,6 +15,7 @@ class ClubsController < ApplicationController
     @memberships = @club.memberships.includes(:user)
     @club_owner = @club.owned_by?(Current.user)
     @invite_token = @club.signed_id(expires_in: 1.week)
+    @current_cycle = @club.current_cycle
   end
 
   def edit
@@ -39,6 +40,7 @@ class ClubsController < ApplicationController
     ActiveRecord::Base.transaction do
       @club.save!
       @club.memberships.create!(user: Current.user, role: :owner)
+      @club.cycles.create!(state: :nominating)
     end
 
     @clubs = clubs_for_current_user

--- a/app/controllers/nominations_controller.rb
+++ b/app/controllers/nominations_controller.rb
@@ -1,0 +1,44 @@
+class NominationsController < ApplicationController
+  before_action :set_cycle_and_club
+
+  def create
+    book = BookFindOrCreateService.call(book_result_from_params)
+    nomination = @cycle.nominations.find_or_initialize_by(user: Current.user)
+    nomination.book = book
+
+    if nomination.save
+      @nomination = nomination
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to @club }
+      end
+    else
+      redirect_to @club, alert: nomination.errors.full_messages.to_sentence
+    end
+  end
+
+  private
+
+  def set_cycle_and_club
+    @cycle = Cycle.find(params[:cycle_id])
+    @club = @cycle.club
+
+    unless @cycle.nominating?
+      redirect_to @club, alert: "This club doesn't have an active cycle."
+    end
+  end
+
+  def book_result_from_params
+    BookLookupService::Result.new(
+      google_books_id: params[:google_books_id],
+      title: params[:title],
+      authors: params[:authors],
+      isbn: params[:isbn],
+      description: params[:description],
+      cover_url: params[:cover_url],
+      publisher: params[:publisher],
+      published_date: params[:published_date],
+      page_count: params[:page_count]
+    )
+  end
+end

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -12,9 +12,23 @@
       <% end %>
       <p><strong><%= book.title %></strong></p>
       <p><%= book.authors %></p>
-      <%# page_count can be nil or 0 from Google Books — both treated as absent %>
       <% if book.page_count.presence&.positive? %>
         <p><%= book.page_count %> pages</p>
+      <% end %>
+
+      <% if params[:cycle_id].present? %>
+        <%= form_with url: cycle_nominations_path(params[:cycle_id]) do |f| %>
+          <%= f.hidden_field :google_books_id, value: book.google_books_id %>
+          <%= f.hidden_field :title, value: book.title %>
+          <%= f.hidden_field :authors, value: book.authors %>
+          <%= f.hidden_field :isbn, value: book.isbn %>
+          <%= f.hidden_field :description, value: book.description %>
+          <%= f.hidden_field :cover_url, value: book.cover_image_url %>
+          <%= f.hidden_field :publisher, value: book.publisher %>
+          <%= f.hidden_field :published_date, value: book.published_date %>
+          <%= f.hidden_field :page_count, value: book.page_count %>
+          <%= f.submit "Nominate" %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/books/_search_and_nominate.html.erb
+++ b/app/views/books/_search_and_nominate.html.erb
@@ -1,0 +1,12 @@
+<div id="nomination_search">
+  <%= form_with url: search_books_path, method: :get,
+        data: { controller: "book-search", turbo_stream: true } do |f| %>
+    <%= f.text_field :query,
+          placeholder: "Search by title or author...",
+          data: { book_search_target: "input", action: "input->book-search#debouncedSubmit" } %>
+    <%= f.hidden_field :cycle_id, value: cycle.id %>
+    <%= f.submit "Search" %>
+  <% end %>
+
+  <div id="book-results"></div>
+</div>

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -18,5 +18,17 @@
     <p><%= link_to "Delete Club", club_path(@club), data: { turbo_method: :delete, turbo_confirm: "Delete this club?", turbo_frame: "_top" } %></p>
   <% end %>
 
+  <% if @current_cycle&.nominating? %>
+    <h2>Current Nominations</h2>
+    <div id="nominations_list">
+      <%= render @current_cycle.nominations.includes(:book, :user),
+            partial: "nominations/nomination",
+            as: :nomination %>
+    </div>
+
+    <h2>Nominate a Book</h2>
+    <%= render "books/search_and_nominate", club: @club, cycle: @current_cycle %>
+  <% end %>
+
   <p><%= link_to "Back to Clubs", clubs_path, data: { turbo_frame: "_top" } %></p>
 <% end %>

--- a/app/views/nominations/_nomination.html.erb
+++ b/app/views/nominations/_nomination.html.erb
@@ -1,0 +1,8 @@
+<div id="<%= dom_id(nomination) %>">
+  <p>
+    <strong><%= nomination.book.title %></strong>
+    —
+    <%= nomination.book.authors %>
+  </p>
+  <p>Nominated by <%= nomination.user.email_address %></p>
+</div>

--- a/app/views/nominations/create.turbo_stream.erb
+++ b/app/views/nominations/create.turbo_stream.erb
@@ -1,0 +1,13 @@
+<% if @nomination.previously_new_record? %>
+  <%= turbo_stream.append "nominations_list" do %>
+    <%= render "nominations/nomination", nomination: @nomination %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.replace dom_id(@nomination) do %>
+    <%= render "nominations/nomination", nomination: @nomination %>
+  <% end %>
+<% end %>
+
+<%= turbo_stream.update "nomination_search" do %>
+  <%= render "books/search_and_nominate", club: @club, cycle: @cycle %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,12 +7,17 @@ Rails.application.routes.draw do
   # Core app
   root "clubs#index"
 
-  resources :clubs, only: %i[index show new create edit update destroy]
   get "/invites/:signed_id", to: "invites#show", as: :invite
 
   resources :books, only: [] do
     collection do
       get :search
+    end
+  end
+
+  resources :clubs, only: %i[index show new create edit update destroy] do
+    resources :cycles, shallow: true do
+      resources :nominations, only: [ :create ], shallow: true
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,8 +36,13 @@ end
 
 puts "Created #{Membership.count} membership(s)"
 
-# TODO: Seed a Cycle in mid-voting state once Cycle model exists (Day 4)
+# Cycle
+unless club.current_cycle
+  club.cycles.create!(state: :nominating)
+end
+
+puts "Cycles: #{Cycle.count}"
+
 # TODO: Seed Nominations and Votes once those models exist (Day 4/5)
-# TODO: Seed Books with Google Books data once Book model exists (Day 3)
 
 puts "Done."

--- a/test/controllers/nominations_controller_test.rb
+++ b/test/controllers/nominations_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class NominationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @cycle = cycles(:nominating)
+    @book = books(:oathbringer)
+  end
+
+  def book_params(book_fixture = @book)
+    {
+      google_books_id: book_fixture.google_books_id,
+      title: book_fixture.title,
+      authors: book_fixture.authors,
+      isbn: book_fixture.isbn,
+      description: book_fixture.description,
+      cover_url: book_fixture.cover_url,
+      publisher: book_fixture.publisher,
+      published_date: book_fixture.published_date,
+      page_count: book_fixture.page_count
+    }
+  end
+
+  test "member can nominate a book" do
+    sign_in_as(users(:three))
+
+    assert_difference "Nomination.count", 1 do
+      post cycle_nominations_path(@cycle), params: book_params(books(:the_hobbit))
+    end
+
+    assert_redirected_to @cycle.club
+    assert_equal books(:the_hobbit), Nomination.last.book
+    assert_equal users(:three), Nomination.last.user
+  end
+
+  test "duplicate nomination updates existing rather than creating a new one" do
+    sign_in_as(@user)
+
+    # users(:one) already has oathbringer nominated via fixtures —
+    # this updates that nomination to the_hobbit
+    assert_no_difference "Nomination.count" do
+      post cycle_nominations_path(@cycle), params: book_params(books(:the_hobbit))
+    end
+
+    assert_redirected_to @cycle.club
+    assert_equal books(:the_hobbit), @user.nominations.find_by(cycle: @cycle).book
+  end
+
+  test "cannot nominate a book already nominated by another member" do
+    sign_in_as(@user)
+
+    # handmaids_tale is already nominated by users(:two) via fixtures
+    assert_no_difference "Nomination.count" do
+      post cycle_nominations_path(@cycle), params: book_params(books(:handmaids_tale))
+    end
+
+    assert_response :redirect
+    assert_equal "Book has already been taken", flash[:alert]
+  end
+
+  test "cannot nominate when no current cycle exists" do
+    sign_in_as(@user)
+
+    post cycle_nominations_path(cycles(:complete)), params: book_params
+
+    assert_redirected_to clubs(:two)
+    assert_equal "This club doesn't have an active cycle.", flash[:alert]
+  end
+end

--- a/test/fixtures/books.yml
+++ b/test/fixtures/books.yml
@@ -21,3 +21,14 @@ handmaids_tale:
   publisher: "Vintage"
   published_date: "2017"
   page_count: 322
+
+the_hobbit:
+  title: "The Hobbit"
+  authors: "J.R.R. Tolkien"
+  isbn: "9780547928227"
+  google_books_id: "pD6arNyKyi8C"
+  description: "A fantasy novel."
+  cover_url: "http://books.google.com/books/content?id=pD6arNyKyi8C"
+  publisher: "Houghton Mifflin Harcourt"
+  published_date: "2012-09-18"
+  page_count: 366

--- a/test/fixtures/cycles.yml
+++ b/test/fixtures/cycles.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
+nominating:
   club: one
   state: nominating
 
-two:
+complete:
   club: two
-  state: voting
+  state: complete

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -1,9 +1,14 @@
-one:
+owner:
   user: one
   club: one
   role: "owner"
 
-two:
+member:
   user: two
+  club: one
+  role: "member"
+
+member_two:
+  user: three
   club: one
   role: "member"

--- a/test/fixtures/nominations.yml
+++ b/test/fixtures/nominations.yml
@@ -1,9 +1,9 @@
-one:
+oathbringer:
   book: oathbringer
-  cycle: one
+  cycle: nominating
   user: one
 
-two:
+handmaids_tale:
   book: handmaids_tale
-  cycle: one
+  cycle: nominating
   user: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,3 +7,7 @@ one:
 two:
   email_address: two@example.com
   password_digest: <%= password_digest %>
+
+three:
+  email_address: three@example.com
+  password_digest: <%= password_digest %>

--- a/test/models/club_test.rb
+++ b/test/models/club_test.rb
@@ -33,7 +33,7 @@ class ClubTest < ActiveSupport::TestCase
   end
 
   test "current_cycle returns the active cycle" do
-    active_cycle = cycles(:one)
+    active_cycle = cycles(:nominating)
     assert_equal active_cycle, @club.current_cycle
   end
 

--- a/test/models/cycle_test.rb
+++ b/test/models/cycle_test.rb
@@ -36,21 +36,21 @@ class CycleTest < ActiveSupport::TestCase
 
   # Valid transitions
   test "advance_to_voting! transitions from nominating to voting" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     assert_equal "nominating", cycle.state
     cycle.advance_to_voting!
     assert_equal "voting", cycle.reload.state
   end
 
   test "advance_to_reading! transitions from voting to reading" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     cycle.update!(state: :voting)
     cycle.advance_to_reading!
     assert_equal "reading", cycle.reload.state
   end
 
   test "complete! transitions from reading to complete" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     cycle.update!(state: :reading)
     cycle.complete!
     assert_equal "complete", cycle.reload.state
@@ -58,24 +58,24 @@ class CycleTest < ActiveSupport::TestCase
 
   # Invalid transitions
   test "advance_to_voting! raises when not in nominating state" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     cycle.update!(state: :voting)
     assert_raises(RuntimeError) { cycle.advance_to_voting! }
   end
 
   test "advance_to_reading! raises when not in voting state" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     assert_raises(RuntimeError) { cycle.advance_to_reading! }
   end
 
   test "complete! raises when not in reading state" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     assert_raises(RuntimeError) { cycle.complete! }
   end
 
   # One active cycle per club constraint
   test "is invalid when club already has an active cycle" do
-    existing_cycle = cycles(:one)
+    existing_cycle = cycles(:nominating)
     assert existing_cycle.valid?
 
     new_cycle = Cycle.new(club: @club, state: "nominating")
@@ -84,7 +84,7 @@ class CycleTest < ActiveSupport::TestCase
   end
 
   test "allows a new active cycle after existing cycle is complete" do
-    existing_cycle = cycles(:one)
+    existing_cycle = cycles(:nominating)
     existing_cycle.update!(state: :complete)
 
     new_cycle = Cycle.new(club: @club, state: "nominating")
@@ -92,7 +92,7 @@ class CycleTest < ActiveSupport::TestCase
   end
 
   test "allows multiple complete cycles for a club" do
-    cycle1 = cycles(:one)
+    cycle1 = cycles(:nominating)
     cycle1.update!(state: :complete)
 
     cycle2 = @club.cycles.create!(state: "nominating")
@@ -104,13 +104,13 @@ class CycleTest < ActiveSupport::TestCase
 
   # Belongs to club
   test "belongs to club" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     assert_equal @club, cycle.club
   end
 
   # Timestamps
   test "has timestamps" do
-    cycle = cycles(:one)
+    cycle = cycles(:nominating)
     assert_not_nil cycle.created_at
     assert_not_nil cycle.updated_at
   end

--- a/test/models/membership_test.rb
+++ b/test/models/membership_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class MembershipTest < ActiveSupport::TestCase
   setup do
-    @membership = memberships(:one)
+    @membership = memberships(:owner)
   end
 
   test "is valid with valid attributes" do

--- a/test/models/nomination_test.rb
+++ b/test/models/nomination_test.rb
@@ -2,13 +2,13 @@ require "test_helper"
 
 class NominationTest < ActiveSupport::TestCase
   test "is valid with valid associations" do
-    nomination = nominations(:one)
+    nomination = nominations(:oathbringer)
 
     assert nomination.valid?
   end
 
   test "rejects duplicate nomination for same user and cycle" do
-    existing_nomination = nominations(:one)
+    existing_nomination = nominations(:oathbringer)
     duplicate = Nomination.new(
       cycle: existing_nomination.cycle,
       user: existing_nomination.user,
@@ -20,7 +20,7 @@ class NominationTest < ActiveSupport::TestCase
   end
 
   test "rejects duplicate book nomination in same cycle from different user" do
-    existing_nomination = nominations(:one)
+    existing_nomination = nominations(:oathbringer)
     duplicate = Nomination.new(
       cycle: existing_nomination.cycle,
       user: users(:two),


### PR DESCRIPTION
Add backend wiring and Turbo-driven UI flow to let members search for books and nominate directly into the club’s active cycle.

- add global user lookup in ApplicationController for session-backed access in nomination flows
- set current cycle on club show and initialize a nominating cycle when creating a club
- add NominationsController#create to:
  - build/find books from search result payload
  - create or update the current user’s nomination in the target cycle
  - enforce cycle must be in nominating state
  - respond with Turbo Stream for in-page updates and HTML redirect fallback
- add nested routes for nominations under cycles/clubs
- add nomination UI components:
  - search-and-nominate partial with cycle-scoped search form
  - nominate action in book search results
  - nomination row partial
  - create Turbo Stream template to append/replace nominations and reset search section
- update club show page to render current nominations and nomination search when an active nominating cycle exists
- update seeds to ensure each club has a current nominating cycle
- expand and rename fixtures to support nomination scenarios (users, cycles, memberships, books, nominations)
- add controller coverage for nomination create behavior:
  - member can nominate
  - repeat nomination updates existing record
  - duplicate book nomination by another member is rejected
  - nominations blocked when no active nominating cycle
- align existing model tests with renamed fixtures and cycle state naming

Closes #34 