### PR TITLE
feat(backend): Vote model, one-per-user-per-cycle

### DIFF
--- a/app/models/nomination.rb
+++ b/app/models/nomination.rb
@@ -3,6 +3,8 @@ class Nomination < ApplicationRecord
   belongs_to :cycle
   belongs_to :user
 
+  has_many :votes, dependent: :destroy
+
   validates :user_id, uniqueness: { scope: :cycle_id }
   validates :book_id, uniqueness: { scope: :cycle_id }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
 
   has_many :sessions, dependent: :destroy
   has_many :nominations, dependent: :destroy
+  has_many :votes, dependent: :destroy
+  has_many :memberships, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,31 @@
+class Vote < ApplicationRecord
+  belongs_to :user
+  belongs_to :nomination
+  belongs_to :cycle
+
+  before_validation :set_cycle_from_nomination
+
+  validates :user_id, uniqueness: {
+    scope: :cycle_id,
+    message: "has already voted in this cycle"
+  }
+
+  validate :cycle_must_be_in_voting_state
+
+  after_destroy_commit :broadcast_tally_update
+
+  private
+
+  def set_cycle_from_nomination
+    self.cycle = nomination&.cycle
+  end
+
+  def cycle_must_be_in_voting_state
+    return unless cycle
+    errors.add(:base, "Voting is not open for this cycle") unless cycle.voting?
+  end
+
+  def broadcast_tally_update
+    # Broadcast logic added in voting UI ticket
+  end
+end

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,9 +1,21 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 1) do
   create_table "solid_cable_messages", force: :cascade do |t|
     t.binary "channel", limit: 1024, null: false
-    t.binary "payload", limit: 536870912, null: false
-    t.datetime "created_at", null: false
     t.integer "channel_hash", limit: 8, null: false
+    t.datetime "created_at", null: false
+    t.binary "payload", limit: 536870912, null: false
     t.index ["channel"], name: "index_solid_cable_messages_on_channel"
     t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
     t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"

--- a/db/migrate/20260421195527_create_votes.rb
+++ b/db/migrate/20260421195527_create_votes.rb
@@ -1,0 +1,13 @@
+class CreateVotes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :votes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :nomination, null: false, foreign_key: true
+      t.references :cycle, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :votes, [ :user_id, :cycle_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_000100) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_195527) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -106,12 +106,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_000100) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.integer "channel_hash", limit: 8, null: false
+    t.datetime "created_at", null: false
+    t.binary "payload", limit: 536870912, null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email_address", null: false
     t.string "password_digest", null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
+  end
+
+  create_table "votes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "cycle_id", null: false
+    t.integer "nomination_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["cycle_id"], name: "index_votes_on_cycle_id"
+    t.index ["nomination_id"], name: "index_votes_on_nomination_id"
+    t.index ["user_id", "cycle_id"], name: "index_votes_on_user_id_and_cycle_id", unique: true
+    t.index ["user_id"], name: "index_votes_on_user_id"
   end
 
   add_foreign_key "clubs", "users", column: "created_by_id"
@@ -122,4 +144,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_000100) do
   add_foreign_key "nominations", "cycles"
   add_foreign_key "nominations", "users"
   add_foreign_key "sessions", "users"
+  add_foreign_key "votes", "cycles"
+  add_foreign_key "votes", "nominations"
+  add_foreign_key "votes", "users"
 end

--- a/test/fixtures/clubs.yml
+++ b/test/fixtures/clubs.yml
@@ -9,3 +9,8 @@ two:
   name: ClubTwo
   description: ClubTwo description
   created_by: two
+
+three:
+  name: ClubThree
+  description: ClubThree description
+  created_by: one

--- a/test/fixtures/cycles.yml
+++ b/test/fixtures/cycles.yml
@@ -7,3 +7,7 @@ nominating:
 complete:
   club: two
   state: complete
+
+voting:
+  club: three
+  state: voting

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -12,3 +12,13 @@ member_two:
   user: three
   club: one
   role: "member"
+
+club_three_owner:
+  user: one
+  club: three
+  role: owner
+
+club_three_member:
+  user: two
+  club: three
+  role: member

--- a/test/fixtures/nominations.yml
+++ b/test/fixtures/nominations.yml
@@ -7,3 +7,13 @@ handmaids_tale:
   book: handmaids_tale
   cycle: nominating
   user: two
+
+voting_one:
+  book: oathbringer
+  cycle: voting
+  user: one
+
+voting_two:
+  book: handmaids_tale
+  cycle: voting
+  user: two

--- a/test/fixtures/votes.yml
+++ b/test/fixtures/votes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  nomination: voting_one
+  cycle: voting
+
+two:
+  user: two
+  nomination: voting_two
+  cycle: voting

--- a/test/models/vote_test.rb
+++ b/test/models/vote_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class VoteTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:three)
+    @nomination = nominations(:voting_one)
+    @cycle = cycles(:voting)
+  end
+
+  test "valid vote is saved and cycle_id is auto-populated" do
+    vote = Vote.new(user: @user, nomination: @nomination)
+
+    assert vote.save
+    assert_equal @cycle.id, vote.cycle_id
+  end
+
+  test "duplicate vote for same user and cycle is rejected" do
+    Vote.create!(user: users(:three), nomination: @nomination, cycle: @cycle)
+
+    duplicate = Vote.new(user: users(:three), nomination: @nomination)
+
+    err = assert_raises(ActiveRecord::RecordInvalid) { duplicate.save! }
+    assert_includes err.message, "User has already voted in this cycle"
+  end
+
+  test "vote is rejected when cycle is not in voting state" do
+    vote = Vote.new(user: @user, nomination: nominations(:oathbringer))
+
+    assert_not vote.valid?
+    assert_includes vote.errors[:base], "Voting is not open for this cycle"
+  end
+
+  test "cycle_id is set from nomination and not accepted from params" do
+    vote = Vote.new(user: @user, nomination: @nomination, cycle_id: 99999)
+
+    assert vote.save
+    assert_equal @cycle.id, vote.cycle_id
+    assert_not_equal 99999, vote.cycle_id
+  end
+end


### PR DESCRIPTION
Vote belongs to User, Nomination, and Cycle. cycle_id is populated automatically from the nomination via before_validation, making it a first-class association rather than a raw column while also serving as the basis for the DB-level uniqueness constraint.

Uniqueness enforced at two levels: model validation on (user_id, cycle_id) and a composite unique index on the same columns. The denormalisation is deliberate—storing cycle_id directly on Vote avoids a join through Nomination to enforce the constraint at the database level.

Custom validation rejects votes when the parent cycle is not in voting state.

after_destroy_commit stub added ready for the voting UI ticket to attach tally broadcast logic.

has_many :votes, dependent: :destroy added to User and Nomination.

Fixtures: added ClubThree with a voting-state cycle, two nominations, and two votes to support Vote model tests without touching existing fixture relationships.

Closes #36 