### PR TITLE
feat(backend): voting UI with live tally via Turbo Streams

### DIFF
--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,0 +1,38 @@
+class VotesController < ApplicationController
+  before_action :set_nomination, only: [ :create ]
+
+  def create
+    vote = Vote.new(user: Current.user, nomination: @nomination)
+
+    if vote.save
+      @vote = vote
+      BroadcastVoteTallyJob.perform_later(@nomination.id)
+      respond_to do |format|
+        format.html { redirect_to @nomination.cycle.club }
+        format.turbo_stream
+      end
+    else
+      redirect_to @nomination.cycle.club,
+        alert: vote.errors.full_messages.to_sentence
+    end
+  end
+
+  def destroy
+    @vote = Vote.find(params[:id])
+    @nomination = @vote.nomination
+    @vote.destroy
+    @nomination.reload
+    BroadcastVoteTallyJob.perform_later(@nomination.id)
+
+    respond_to do |format|
+      format.html { redirect_to @nomination.cycle.club }
+      format.turbo_stream
+    end
+  end
+
+  private
+
+  def set_nomination
+    @nomination = Nomination.includes(:cycle).find(params[:nomination_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def present(record, presenter_class: nil, **kwargs)
+    klass = presenter_class || "#{record.class}Presenter".constantize
+    klass.new(record, self, **kwargs)
+  end
 end

--- a/app/jobs/broadcast_vote_tally_job.rb
+++ b/app/jobs/broadcast_vote_tally_job.rb
@@ -1,0 +1,14 @@
+class BroadcastVoteTallyJob < ApplicationJob
+  queue_as :default
+
+  def perform(nomination_id)
+    nomination = Nomination.find(nomination_id)
+
+    Turbo::StreamsChannel.broadcast_replace_to(
+      "cycle_#{nomination.cycle_id}_votes",
+      target: "nomination_#{nomination_id}_count",
+      partial: "nominations/vote_count",
+      locals: { nomination: nomination }
+    )
+  end
+end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,6 +1,7 @@
 class Cycle < ApplicationRecord
   belongs_to :club
   has_many :nominations, dependent: :destroy
+  has_many :votes, dependent: :destroy
 
   enum :state, { nominating: "nominating", voting: "voting", reading: "reading", complete: "complete" }
 

--- a/app/models/nomination.rb
+++ b/app/models/nomination.rb
@@ -11,6 +11,10 @@ class Nomination < ApplicationRecord
   after_create_commit :broadcast_nomination
   after_update_commit :broadcast_nomination_replace
 
+  def voted_by?(user)
+    votes.exists?(user_id: user.id)
+  end
+
   private
 
   def broadcast_nomination

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -12,8 +12,6 @@ class Vote < ApplicationRecord
 
   validate :cycle_must_be_in_voting_state
 
-  after_destroy_commit :broadcast_tally_update
-
   private
 
   def set_cycle_from_nomination
@@ -23,9 +21,5 @@ class Vote < ApplicationRecord
   def cycle_must_be_in_voting_state
     return unless cycle
     errors.add(:base, "Voting is not open for this cycle") unless cycle.voting?
-  end
-
-  def broadcast_tally_update
-    # Broadcast logic added in voting UI ticket
   end
 end

--- a/app/presenters/application_presenter.rb
+++ b/app/presenters/application_presenter.rb
@@ -1,0 +1,11 @@
+class ApplicationPresenter
+  attr_reader :record, :view_context, :current_user
+
+  delegate_missing_to :record
+
+  def initialize(record, view_context, current_user: nil)
+    @record = record
+    @view_context = view_context
+    @current_user = current_user
+  end
+end

--- a/app/presenters/nomination_presenter.rb
+++ b/app/presenters/nomination_presenter.rb
@@ -1,0 +1,20 @@
+class NominationPresenter < ApplicationPresenter
+  def vote_button
+    if current_user.present? && voted_by?(current_user)
+      view_context.button_to "Remove Vote",
+        view_context.vote_path(votes.find { |v| v.user_id == current_user.id }),
+        method: :delete
+    elsif current_user.present?
+      view_context.button_to "Cast Vote",
+        view_context.nomination_votes_path(nomination),
+        method: :post,
+        disabled: cycle.votes.exists?(user_id: current_user.id)
+    end
+  end
+
+  private
+
+  def nomination
+    record
+  end
+end

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -2,6 +2,10 @@
   <%= turbo_stream_from "cycle_#{@current_cycle.id}_nominations" %>
 <% end %>
 
+<% if @current_cycle&.voting? %>
+  <%= turbo_stream_from "cycle_#{@current_cycle.id}_votes" %>
+<% end %>
+
 <%= turbo_frame_tag "club_details_#{@club.id}" do %>
   <h1><%= @club.name %></h1>
   <p><%= @club.description.presence || "No description provided." %></p>
@@ -32,6 +36,16 @@
 
     <h2>Nominate a Book</h2>
     <%= render "books/search_and_nominate", club: @club, cycle: @current_cycle %>
+  <% end %>
+
+  <% if @current_cycle&.voting? %>
+    <h2>Vote for your favourite nomination</h2>
+    <div id="nominations_list">
+      <%= render partial: "nominations/nomination",
+            collection: @current_cycle.nominations.includes(:book, :user, :votes),
+            as: :nomination,
+            locals: { current_user: Current.user } %>
+    </div>
   <% end %>
 
   <p><%= link_to "Back to Clubs", clubs_path, data: { turbo_frame: "_top" } %></p>

--- a/app/views/nominations/_nomination.html.erb
+++ b/app/views/nominations/_nomination.html.erb
@@ -1,3 +1,6 @@
+<%# instantiate current_user if not already set, for broadcasting or non-voting display purposes %>
+<% current_user ||= nil %>
+
 <div id="<%= "nomination_#{nomination.id}" %>">
   <p>
     <strong><%= nomination.book.title %></strong>
@@ -5,4 +8,12 @@
     <%= nomination.book.authors %>
   </p>
   <p>Nominated by <%= nomination.user.email_address %></p>
+
+  <% if nomination.cycle.voting? && current_user.present? %>
+    <%= present(nomination, current_user:).vote_button %>
+  <% end %>
+
+  <% if nomination.cycle.voting? %>
+    <%= render "nominations/vote_count", nomination: nomination %>
+  <% end %>
 </div>

--- a/app/views/nominations/_vote_count.html.erb
+++ b/app/views/nominations/_vote_count.html.erb
@@ -1,0 +1,3 @@
+<span id="<%= "nomination_#{nomination.id}_count" %>">
+  <%= pluralize(nomination.votes.size, 'vote') %>
+</span>

--- a/app/views/votes/create.turbo_stream.erb
+++ b/app/views/votes/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<% @nomination.cycle.nominations.includes(:book, :user, :votes).each do |nomination| %>
+  <%= turbo_stream.replace "nomination_#{nomination.id}" do %>
+    <%= render "nominations/nomination",
+          nomination: nomination,
+          current_user: Current.user %>
+  <% end %>
+<% end %>

--- a/app/views/votes/destroy.turbo_stream.erb
+++ b/app/views/votes/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<% @nomination.cycle.nominations.includes(:book, :user, :votes).each do |nomination| %>
+  <%= turbo_stream.replace "nomination_#{nomination.id}" do %>
+    <%= render "nominations/nomination",
+          nomination: nomination,
+          current_user: Current.user %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
 
   resources :clubs, only: %i[index show new create edit update destroy] do
     resources :cycles, shallow: true do
-      resources :nominations, only: [ :create ], shallow: true
+      resources :nominations, only: [ :create ], shallow: true do
+        resources :votes, only: [ :create, :destroy ]
+      end
     end
   end
 

--- a/test/controllers/votes_controller_test.rb
+++ b/test/controllers/votes_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class VotesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:three)
+    @nomination = nominations(:voting_one)
+    @cycle = cycles(:voting)
+    @club = clubs(:three)
+  end
+
+  test "member can cast a vote" do
+    sign_in_as(@user)
+
+    assert_difference "Vote.count", 1 do
+      post nomination_votes_path(@nomination)
+    end
+
+    assert_redirected_to @club
+    assert_equal @user, Vote.last.user
+    assert_equal @nomination, Vote.last.nomination
+  end
+
+  test "duplicate vote for same cycle is rejected" do
+    sign_in_as(users(:one))
+
+    # users(:one) already has a vote on voting_one via fixtures
+    post nomination_votes_path(nominations(:voting_two))
+
+    assert_redirected_to @club
+    assert_equal "User has already voted in this cycle", flash[:alert]
+  end
+
+  test "vote rejected when cycle is not in voting state" do
+    sign_in_as(@user)
+
+    post nomination_votes_path(nominations(:oathbringer))
+
+    assert_redirected_to nominations(:oathbringer).cycle.club
+    assert_equal "Voting is not open for this cycle", flash[:alert]
+  end
+end


### PR DESCRIPTION
VotesController with create and destroy actions. Create casts a vote, destroy removes it. Separate actions replace the earlier single-action approach that tried to handle both create and delete in one method.

Vote tally broadcasts handled by BroadcastVoteTallyJob rather than model callbacks. after_create_commit on Vote was unreliable in the Solid Cable/SQLite threading context—the callback fired inside the SolidCable::TrimJob thread and was silently swallowed. Moving the broadcast to an explicit job dispatched from the controller sidesteps the threading issue entirely. The job uses
Turbo::StreamsChannel.broadcast_replace_to targeting the vote count span only, preserving other users' button state.

Vote count extracted to _vote_count.html.erb partial, shared between the view render and the broadcast job via
ApplicationController.renderer. Single source of truth for the count markup.

Presenter layer introduced: ApplicationPresenter base class with delegate_missing_to, NominationPresenter handling vote button logic (Cast Vote / Remove Vote / disabled state). ApplicationHelper#present helper for instantiation in views. Button state is user-specific—once a user has voted, Cast Vote buttons on other nominations are disabled until they remove their vote.

Turbo Stream templates for create and destroy both re-render all nomination rows for the voter, ensuring button state is consistent across the full list. Broadcasts only update the count span, avoiding the current_user availability issue in background threads.

Collection partial rendering uses explicit render partial: with collection: and locals: rather than the shorthand—the shorthand does not reliably forward locals to each partial iteration.

Routes: votes nested under nominations with shallow routing. POST /nominations/:id/votes for create, DELETE /votes/:id for destroy.

Request tests cover successful vote, duplicate vote rejected, and vote rejected when cycle not in voting state.