### PR TITLE
feat(backend): close-voting action that declares a winner

### DIFF
--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,0 +1,30 @@
+class CyclesController < ApplicationController
+  before_action :set_cycle_and_club
+  before_action :require_club_owner!, only: [ :close_voting ]
+
+  def close_voting
+    result = @cycle.close_voting_and_select_winner!
+
+    message = result == :tied ?
+      "Voting closed. A tie was randomly broken to select the winner." : "Voting closed."
+
+    redirect_to @club, notice: message
+  rescue RuntimeError => error
+    redirect_to @club, alert: error.message
+  end
+
+  private
+
+  def set_cycle_and_club
+    @cycle = Cycle.joins(club: :memberships)
+      .where(memberships: { user_id: Current.user.id })
+      .includes(:club)
+      .find(params[:id])
+
+    @club = @cycle.club
+  end
+
+  def require_club_owner!
+    head :forbidden unless @club.owned_by?(Current.user)
+  end
+end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -1,6 +1,7 @@
 class VotesController < ApplicationController
   before_action :set_nomination, only: [ :create ]
   before_action :set_vote, only: [ :destroy ]
+  before_action :require_vote_owner!, only: [ :destroy ]
 
   def create
     vote = Vote.new(user: Current.user, nomination: @nomination)
@@ -19,8 +20,6 @@ class VotesController < ApplicationController
   end
 
   def destroy
-    return head :forbidden unless @vote.user_id == Current.user.id
-
     @nomination = @vote.nomination
     @vote.destroy
     BroadcastVoteTallyJob.perform_later(@nomination.id)
@@ -41,5 +40,9 @@ class VotesController < ApplicationController
 
   def set_vote
     @vote = Vote.find(params[:id])
+  end
+
+  def require_vote_owner!
+    head :forbidden unless @vote.user_id == Current.user.id
   end
 end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -1,5 +1,6 @@
 class Cycle < ApplicationRecord
   belongs_to :club
+  belongs_to :winning_nomination, class_name: "Nomination", optional: true
   has_many :nominations, dependent: :destroy
   has_many :votes, dependent: :destroy
 
@@ -12,19 +13,35 @@ class Cycle < ApplicationRecord
     message: "can only have one active cycle at a time"
   }
 
+  validates :winning_nomination, presence: true, if: -> { reading? }
+
   # Transition methods - each raises on invalid transition
-  def advance_to_voting!
+  def close_nominations!
     raise "Cannot advance to voting from #{state}" unless nominating?
+    raise "Cannot advance to voting without any nominations" if nominations.none?
     update!(state: :voting)
   end
 
-  def advance_to_reading!
-    raise "Cannot advance to reading from #{state}" unless voting?
-    update!(state: :reading)
+  def close_voting_and_select_winner!
+    raise "Cannot close voting from #{state}" unless voting?
+
+    counts = vote_counts_by_nomination_id
+    raise "Cannot close voting without any votes" if counts.values.all?(&:zero?)
+
+    max_votes = counts.values.max
+    vote_leaders = counts.select { |_id, votes| votes == max_votes }.keys
+    winner_id = vote_leaders.sample
+
+    update!(winning_nomination_id: winner_id, state: :reading)
+    vote_leaders.many? ? :tied : :clear_winner
   end
 
   def complete!
     raise "Cannot complete from #{state}" unless reading?
     update!(state: :complete)
+  end
+
+  def vote_counts_by_nomination_id
+    nominations.left_joins(:votes).group("nominations.id").count("votes.id")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Rails.application.routes.draw do
 
   resources :clubs, only: %i[index show new create edit update destroy] do
     resources :cycles, shallow: true do
+      member do
+        patch :close_voting
+      end
+
       resources :nominations, only: [ :create ], shallow: true do
         resources :votes, only: [ :create, :destroy ]
       end

--- a/db/migrate/20260422090000_add_winning_nomination_to_cycles.rb
+++ b/db/migrate/20260422090000_add_winning_nomination_to_cycles.rb
@@ -1,0 +1,5 @@
+class AddWinningNominationToCycles < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :cycles, :winning_nomination, null: true, foreign_key: { to_table: :nominations }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_195527) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_090000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -69,8 +69,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_195527) do
     t.datetime "created_at", null: false
     t.string "state", default: "nominating", null: false
     t.datetime "updated_at", null: false
+    t.integer "winning_nomination_id"
     t.index ["club_id"], name: "index_cycles_on_club_id"
     t.index ["club_id"], name: "index_cycles_on_club_id_where_state_not_complete", unique: true, where: "state != 'complete'"
+    t.index ["winning_nomination_id"], name: "index_cycles_on_winning_nomination_id"
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -138,6 +140,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_195527) do
 
   add_foreign_key "clubs", "users", column: "created_by_id"
   add_foreign_key "cycles", "clubs"
+  add_foreign_key "cycles", "nominations", column: "winning_nomination_id"
   add_foreign_key "memberships", "clubs"
   add_foreign_key "memberships", "users"
   add_foreign_key "nominations", "books"

--- a/test/controllers/cycles_controller_test.rb
+++ b/test/controllers/cycles_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class CyclesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @owner = users(:one)
+    @non_owner = users(:two)
+    @voting_cycle = cycles(:voting)
+  end
+
+  test "owner can close voting with a clear winner" do
+    sign_in_as(@owner)
+
+    Vote.create!(user: users(:three), nomination: nominations(:voting_one))
+
+    patch close_voting_cycle_path(@voting_cycle)
+
+    assert_redirected_to @voting_cycle.club
+    assert_equal "Voting closed.", flash[:notice]
+
+    @voting_cycle.reload
+    assert_equal "reading", @voting_cycle.state
+    assert_equal nominations(:voting_one), @voting_cycle.winning_nomination
+  end
+
+  test "owner can close voting with a tie" do
+    sign_in_as(@owner)
+
+    patch close_voting_cycle_path(@voting_cycle)
+
+    assert_redirected_to @voting_cycle.club
+    assert_equal "Voting closed. A tie was randomly broken to select the winner.", flash[:notice]
+
+    @voting_cycle.reload
+    assert_equal "reading", @voting_cycle.state
+    assert_includes [ nominations(:voting_one), nominations(:voting_two) ], @voting_cycle.winning_nomination
+  end
+
+  test "non-owner gets 403 when trying to close voting" do
+    sign_in_as(@non_owner)
+
+    patch close_voting_cycle_path(@voting_cycle)
+
+    assert_response :forbidden
+    assert_equal "voting", @voting_cycle.reload.state
+    assert_nil @voting_cycle.winning_nomination
+  end
+
+  test "close voting is rejected when cycle is not in voting state" do
+    sign_in_as(@owner)
+    non_voting_cycle = cycles(:nominating)
+
+    patch close_voting_cycle_path(non_voting_cycle)
+
+    assert_redirected_to non_voting_cycle.club
+    assert_equal "Cannot close voting from nominating", flash[:alert]
+    assert_equal "nominating", non_voting_cycle.reload.state
+    assert_nil non_voting_cycle.winning_nomination
+  end
+end

--- a/test/models/cycle_test.rb
+++ b/test/models/cycle_test.rb
@@ -35,37 +35,65 @@ class CycleTest < ActiveSupport::TestCase
   end
 
   # Valid transitions
-  test "advance_to_voting! transitions from nominating to voting" do
+  test "close_nominations! transitions from nominating to voting" do
     cycle = cycles(:nominating)
     assert_equal "nominating", cycle.state
-    cycle.advance_to_voting!
+    cycle.close_nominations!
     assert_equal "voting", cycle.reload.state
   end
 
-  test "advance_to_reading! transitions from voting to reading" do
-    cycle = cycles(:nominating)
-    cycle.update!(state: :voting)
-    cycle.advance_to_reading!
+  test "close_voting_and_select_winner! returns :clear_winner and sets the leading nomination" do
+    cycle = cycles(:voting)
+    # voting_one and voting_two each have 1 vote via fixtures — add a second vote to voting_one
+    Vote.create!(user: users(:three), nomination: nominations(:voting_one), cycle: cycle)
+
+    result = cycle.close_voting_and_select_winner!
+
+    assert_equal :clear_winner, result
     assert_equal "reading", cycle.reload.state
+    assert_equal nominations(:voting_one), cycle.winning_nomination
+  end
+
+  test "close_voting_and_select_winner! returns :tied and picks a winner randomly on a tie" do
+    cycle = cycles(:voting)
+    # voting_one and voting_two each have exactly 1 vote via fixtures — genuine tie
+
+    result = cycle.close_voting_and_select_winner!
+
+    assert_equal :tied, result
+    assert_equal "reading", cycle.reload.state
+    assert_includes [ nominations(:voting_one), nominations(:voting_two) ], cycle.winning_nomination
   end
 
   test "complete! transitions from reading to complete" do
-    cycle = cycles(:nominating)
-    cycle.update!(state: :reading)
+    cycle = cycles(:voting)
+    cycle.close_voting_and_select_winner!
     cycle.complete!
     assert_equal "complete", cycle.reload.state
   end
 
   # Invalid transitions
-  test "advance_to_voting! raises when not in nominating state" do
+  test "close_nominations! raises when not in nominating state" do
     cycle = cycles(:nominating)
     cycle.update!(state: :voting)
-    assert_raises(RuntimeError) { cycle.advance_to_voting! }
+    assert_raises(RuntimeError) { cycle.close_nominations! }
   end
 
-  test "advance_to_reading! raises when not in voting state" do
+  test "close_nominations! raises when there are no nominations" do
+    club = Club.create!(name: "Empty Club", created_by: users(:one))
+    cycle = club.cycles.create!(state: :nominating)
+    assert_raises(RuntimeError) { cycle.close_nominations! }
+  end
+
+  test "close_voting_and_select_winner! raises when not in voting state" do
     cycle = cycles(:nominating)
-    assert_raises(RuntimeError) { cycle.advance_to_reading! }
+    assert_raises(RuntimeError) { cycle.close_voting_and_select_winner! }
+  end
+
+  test "close_voting_and_select_winner! raises when no votes have been cast" do
+    cycle = cycles(:voting)
+    cycle.votes.delete_all
+    assert_raises(RuntimeError) { cycle.close_voting_and_select_winner! }
   end
 
   test "complete! raises when not in reading state" do


### PR DESCRIPTION
- add cycles close-voting flow that transitions a cycle from voting to reading
- persist winning nomination via winning_nomination_id on cycles
- add winner association and transition guards in Cycle
- enforce no-close when no votes have been cast
- compute vote totals with left join grouped by nomination and count votes.id
- support tie handling by randomly selecting among top-voted nominations
- return tie/clear-winner result for controller flash messaging
- add owner-only controller endpoint and route for closing voting
- update request/model tests for clear winner, tie, forbidden non-owner, and invalid state
- remove obsolete advance-to-reading transition path

Closes #38 