### PR TITLE
feat(backend): wire transition UI for nominating and voting states

### DIFF
--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -13,7 +13,7 @@ class ClubsController < ApplicationController
 
   def show
     @memberships = @club.memberships.includes(:user)
-    @club_owner = @club.owned_by?(Current.user)
+    @is_owner = @club.owned_by?(Current.user)
     @invite_token = @club.signed_id(expires_in: 1.week)
     @current_cycle = @club.current_cycle
   end

--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,6 +1,18 @@
 class CyclesController < ApplicationController
   before_action :set_cycle_and_club
-  before_action :require_club_owner!, only: [ :close_voting ]
+  before_action :require_club_owner!, only: [ :close_voting, :close_nominations ]
+
+  # Handle errors from invalid state transitions in the cycle model
+  # TODO - extract transition logic to service and raise more specific
+  # exceptions to avoid rescuing unexpected errors
+  rescue_from RuntimeError do |error|
+    redirect_to @club, alert: error.message, status: :see_other
+  end
+
+  def close_nominations
+    @cycle.close_nominations!
+    redirect_to @club, notice: "Nominations closed.", status: :see_other
+  end
 
   def close_voting
     result = @cycle.close_voting_and_select_winner!
@@ -8,9 +20,7 @@ class CyclesController < ApplicationController
     message = result == :tied ?
       "Voting closed. A tie was randomly broken to select the winner." : "Voting closed."
 
-    redirect_to @club, notice: message
-  rescue RuntimeError => error
-    redirect_to @club, alert: error.message
+    redirect_to @club, notice: message, status: :see_other
   end
 
   private

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -9,6 +9,7 @@ class VotesController < ApplicationController
     if vote.save
       @vote = vote
       BroadcastVoteTallyJob.perform_later(@nomination.id)
+
       respond_to do |format|
         format.html { redirect_to @nomination.cycle.club }
         format.turbo_stream

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -15,6 +15,8 @@ class Cycle < ApplicationRecord
 
   validates :winning_nomination, presence: true, if: -> { reading? }
 
+  after_update :broadcast_state_change, if: :saved_change_to_state?
+
   # Transition methods - each raises on invalid transition
   def close_nominations!
     raise "Cannot advance to voting from #{state}" unless nominating?
@@ -41,7 +43,13 @@ class Cycle < ApplicationRecord
     update!(state: :complete)
   end
 
+  private
+
   def vote_counts_by_nomination_id
     nominations.left_joins(:votes).group("nominations.id").count("votes.id")
+  end
+
+  def broadcast_state_change
+    Turbo::StreamsChannel.broadcast_refresh_to("club_#{club.id}")
   end
 end

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from "club_#{@club.id}" %>
+
 <% if @current_cycle&.nominating? %>
   <%= turbo_stream_from "cycle_#{@current_cycle.id}_nominations" %>
 <% end %>
@@ -17,13 +19,21 @@
     <% end %>
   </ul>
 
-  <% if @club_owner %>
+  <% if @is_owner %>
     <div data-controller="clipboard">
       <p>Invite link: <span data-clipboard-target="source"><%= invite_url(signed_id: @invite_token) %></span></p>
       <button data-clipboard-target="button" data-action="clipboard#copy">Copy to Clipboard</button>
     </div>
     <p><%= link_to "Edit Club", edit_club_path(@club) %></p>
     <p><%= link_to "Delete Club", club_path(@club), data: { turbo_method: :delete, turbo_confirm: "Delete this club?", turbo_frame: "_top" } %></p>
+  <% end %>
+
+  <% if @is_owner && @current_cycle&.nominating? %>
+    <%= button_to "Close Nominations", close_nominations_cycle_path(@current_cycle), method: :patch, data: { turbo_frame: "_top" } %>
+  <% end %>
+
+  <% if @is_owner && @current_cycle&.voting? %>
+    <%= button_to "Close Voting", close_voting_cycle_path(@current_cycle), method: :patch, data: { turbo_frame: "_top" } %>
   <% end %>
 
   <% if @current_cycle&.nominating? %>
@@ -47,6 +57,6 @@
             locals: { current_user: Current.user } %>
     </div>
   <% end %>
-
-  <p><%= link_to "Back to Clubs", clubs_path, data: { turbo_frame: "_top" } %></p>
 <% end %>
+
+<p><%= link_to "Back to Clubs", clubs_path, data: { turbo_frame: "_top" } %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     resources :cycles, shallow: true do
       member do
         patch :close_voting
+        patch :close_nominations
       end
 
       resources :nominations, only: [ :create ], shallow: true do

--- a/test/controllers/cycles_controller_test.rb
+++ b/test/controllers/cycles_controller_test.rb
@@ -4,7 +4,50 @@ class CyclesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @owner = users(:one)
     @non_owner = users(:two)
+    @nominating_cycle = cycles(:nominating)
     @voting_cycle = cycles(:voting)
+  end
+
+  test "owner can close nominations" do
+    sign_in_as(@owner)
+
+    patch close_nominations_cycle_path(@nominating_cycle)
+
+    assert_redirected_to @nominating_cycle.club
+    assert_equal "Nominations closed.", flash[:notice]
+
+    @nominating_cycle.reload
+    assert_equal "voting", @nominating_cycle.state
+  end
+
+  test "non-owner gets 403 when trying to close nominations" do
+    sign_in_as(@non_owner)
+
+    patch close_nominations_cycle_path(@nominating_cycle)
+
+    assert_response :forbidden
+    assert_equal "nominating", @nominating_cycle.reload.state
+  end
+
+  test "close nominations is rejected when cycle is not in nominating state" do
+    sign_in_as(@owner)
+
+    patch close_nominations_cycle_path(@voting_cycle)
+
+    assert_redirected_to @voting_cycle.club
+    assert_equal "Cannot advance to voting from voting", flash[:alert]
+    assert_equal "voting", @voting_cycle.reload.state
+  end
+
+  test "close nominations is rejected when there are no nominations" do
+    sign_in_as(@owner)
+    @nominating_cycle.nominations.destroy_all
+
+    patch close_nominations_cycle_path(@nominating_cycle)
+
+    assert_redirected_to @nominating_cycle.club
+    assert_equal "Cannot advance to voting without any nominations", flash[:alert]
+    assert_equal "nominating", @nominating_cycle.reload.state
   end
 
   test "owner can close voting with a clear winner" do
@@ -55,5 +98,17 @@ class CyclesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Cannot close voting from nominating", flash[:alert]
     assert_equal "nominating", non_voting_cycle.reload.state
     assert_nil non_voting_cycle.winning_nomination
+  end
+
+  test "close voting is rejected when there are no votes" do
+    sign_in_as(@owner)
+    @voting_cycle.votes.destroy_all
+
+    patch close_voting_cycle_path(@voting_cycle)
+
+    assert_redirected_to @voting_cycle.club
+    assert_equal "Cannot close voting without any votes", flash[:alert]
+    assert_equal "voting", @voting_cycle.reload.state
+    assert_nil @voting_cycle.winning_nomination
   end
 end


### PR DESCRIPTION
Add close_nominations as a member cycle action with owner authorization, routing, and controller handling.

Render owner-only transition buttons on the club page for nominating and voting states, using top-level Turbo navigation for PATCH requests so flash behavior is consistent.

Subscribe the club page to a club-level Turbo stream and broadcast refresh updates when cycle state changes so connected members see state transitions promptly.

Use 303 See Other for transition redirects, including RuntimeError rescue redirects, for consistent non-GET redirect semantics.

Expand cycle transition controller coverage for close_nominations success/forbidden/wrong-state, plus explicit no-nominations and no-votes rejection paths.

Closes #84 