### PR TITLE
feat(backend): ReadingLogEntry model with start/progress/finish states and UI

### DIFF
--- a/app/controllers/reading_log_entries_controller.rb
+++ b/app/controllers/reading_log_entries_controller.rb
@@ -1,0 +1,57 @@
+class ReadingLogEntriesController < ApplicationController
+  before_action :set_cycle_and_club
+
+  def create
+    @reading_log_entry = @cycle.reading_log_entries.new(reading_log_entry_params)
+    @reading_log_entry.user = Current.user
+
+    if @reading_log_entry.save
+      @reading_log_entry = ReadingLogEntry.new
+
+      respond_to do |format|
+        format.html { redirect_to @club }
+        format.turbo_stream { render_reading_frame }
+      end
+    else
+      respond_to do |format|
+        format.html { redirect_to @club, alert: @reading_log_entry.errors.full_messages.to_sentence }
+        format.turbo_stream { render_reading_frame(status: :unprocessable_entity) }
+      end
+    end
+  end
+
+  private
+
+  def set_cycle_and_club
+    @cycle = Cycle.joins(club: :memberships)
+      .where(memberships: { user_id: Current.user.id })
+      .includes(:club, winning_nomination: :book)
+      .find(params[:cycle_id])
+
+    @club = @cycle.club
+  rescue ActiveRecord::RecordNotFound
+    head :forbidden
+  end
+
+  def reading_log_entry_params
+    params.expect(reading_log_entry: [ :state, :page_reached, :note ])
+  end
+
+  def render_reading_frame(status: :ok)
+    render turbo_stream: turbo_stream.replace(
+      helpers.dom_id(@cycle, :reading_log_entries),
+      partial: "clubs/reading_log_entries_frame",
+      locals: {
+        cycle: @cycle,
+        reading_log_entry: @reading_log_entry,
+        reading_log_entries: current_user_entries
+      }
+    ), status: status
+  end
+
+  def current_user_entries
+    @cycle.reading_log_entries
+      .where(user: Current.user)
+      .order(created_at: :desc)
+  end
+end

--- a/app/models/cycle.rb
+++ b/app/models/cycle.rb
@@ -3,6 +3,7 @@ class Cycle < ApplicationRecord
   belongs_to :winning_nomination, class_name: "Nomination", optional: true
   has_many :nominations, dependent: :destroy
   has_many :votes, dependent: :destroy
+  has_many :reading_log_entries, dependent: :destroy
 
   enum :state, { nominating: "nominating", voting: "voting", reading: "reading", complete: "complete" }
 

--- a/app/models/reading_log_entry.rb
+++ b/app/models/reading_log_entry.rb
@@ -1,0 +1,36 @@
+class ReadingLogEntry < ApplicationRecord
+  belongs_to :user
+  belongs_to :cycle
+
+  enum :state, {
+    started: "started",
+    progressed: "progressed",
+    finished: "finished"
+  }
+
+  validates :state, presence: true
+  validates :page_reached,
+    numericality: { only_integer: true, greater_than: 0 },
+    allow_nil: true
+
+  validate :cycle_must_be_in_reading_state
+  validate :page_reached_cannot_exceed_book_page_count
+
+  private
+
+  def cycle_must_be_in_reading_state
+    return unless cycle
+
+    errors.add(:base, "Reading log is not open for this cycle") unless cycle.reading?
+  end
+
+  def page_reached_cannot_exceed_book_page_count
+    return if page_reached.nil?
+
+    page_count = cycle&.winning_nomination&.book&.page_count
+    return if page_count.nil?
+    return if page_reached <= page_count
+
+    errors.add(:page_reached, "cannot be greater than total pages (#{page_count})")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :nominations, dependent: :destroy
   has_many :votes, dependent: :destroy
   has_many :memberships, dependent: :destroy
+  has_many :reading_log_entries, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 end

--- a/app/views/clubs/_reading.html.erb
+++ b/app/views/clubs/_reading.html.erb
@@ -1,0 +1,19 @@
+<h2>Current Read</h2>
+
+<% if cycle.winning_nomination&.book.present? %>
+  <p>
+    <strong>Winning book:</strong>
+    <%= cycle.winning_nomination.book.title %>
+    <% if cycle.winning_nomination.book.cover_image_url.present? %>
+      <%= image_tag cycle.winning_nomination.book.cover_image_url, alt: cycle.winning_nomination.book.title %>
+    <% end %>
+    <% if cycle.winning_nomination.book.authors.present? %>
+      by <%= cycle.winning_nomination.book.authors %>
+    <% end %>
+  </p>
+<% end %>
+
+<%= render "reading_log_entries_frame",
+  cycle: cycle,
+  reading_log_entry: reading_log_entry,
+  reading_log_entries: reading_log_entries %>

--- a/app/views/clubs/_reading_log_entries_frame.html.erb
+++ b/app/views/clubs/_reading_log_entries_frame.html.erb
@@ -1,0 +1,35 @@
+<%= turbo_frame_tag dom_id(cycle, :reading_log_entries) do %>
+  <% if reading_log_entry.errors.any? %>
+    <p><%= reading_log_entry.errors.full_messages.to_sentence %></p>
+  <% end %>
+
+  <h3>Log your reading</h3>
+  <%= form_with model: reading_log_entry, url: cycle_reading_log_entries_path(cycle) do |form| %>
+    <p>
+      <%= form.label :state %><br>
+      <%= form.select :state, ReadingLogEntry.states.keys.map { |value| [ value.humanize, value ] } %>
+    </p>
+
+    <p>
+      <%= form.label :page_reached %><br>
+      <%= form.number_field :page_reached, min: 1 %>
+    </p>
+
+    <p>
+      <%= form.label :note %><br>
+      <%= form.text_area :note, rows: 4 %>
+    </p>
+
+    <%= form.submit "Save reading log" %>
+  <% end %>
+
+  <h3>Your reading log</h3>
+
+  <% if reading_log_entries.any? %>
+    <div id="reading_log_entries_list">
+      <%= render reading_log_entries %>
+    </div>
+  <% else %>
+    <p>No reading updates yet.</p>
+  <% end %>
+<% end %>

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -59,4 +59,12 @@
   <% end %>
 <% end %>
 
+<% if @current_cycle&.reading? %>
+  <%= render "reading",
+        club: @club,
+        cycle: @current_cycle,
+        reading_log_entry: ReadingLogEntry.new,
+        reading_log_entries: @current_cycle.reading_log_entries.where(user: Current.user).order(created_at: :desc) %>
+<% end %>
+
 <p><%= link_to "Back to Clubs", clubs_path, data: { turbo_frame: "_top" } %></p>

--- a/app/views/reading_log_entries/_reading_log_entry.html.erb
+++ b/app/views/reading_log_entries/_reading_log_entry.html.erb
@@ -1,0 +1,14 @@
+<article id="<%= dom_id(reading_log_entry) %>">
+  <p>
+    <strong><%= reading_log_entry.state.humanize %></strong>
+    <span>on <%= reading_log_entry.created_at.strftime("%d %b %Y") %></span>
+  </p>
+
+  <% if reading_log_entry.page_reached.present? %>
+    <p>Page reached: <%= reading_log_entry.page_reached %></p>
+  <% end %>
+
+  <% if reading_log_entry.note.present? %>
+    <p><%= reading_log_entry.note %></p>
+  <% end %>
+</article>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
       resources :nominations, only: [ :create ], shallow: true do
         resources :votes, only: [ :create, :destroy ]
       end
+
+      resources :reading_log_entries, only: [ :create ], shallow: true
     end
   end
 

--- a/db/migrate/20260422101500_create_reading_log_entries.rb
+++ b/db/migrate/20260422101500_create_reading_log_entries.rb
@@ -1,0 +1,16 @@
+class CreateReadingLogEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :reading_log_entries do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :cycle, null: false, foreign_key: true
+      t.string :state, null: false
+      t.integer :page_reached
+      t.text :note
+
+      t.timestamps
+    end
+
+    add_index :reading_log_entries, [ :user_id, :cycle_id ]
+    add_index :reading_log_entries, [ :cycle_id, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_090000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_101500) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -99,6 +99,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_090000) do
     t.index ["user_id"], name: "index_nominations_on_user_id"
   end
 
+  create_table "reading_log_entries", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "cycle_id", null: false
+    t.text "note"
+    t.integer "page_reached"
+    t.string "state", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["cycle_id", "created_at"], name: "index_reading_log_entries_on_cycle_id_and_created_at"
+    t.index ["cycle_id"], name: "index_reading_log_entries_on_cycle_id"
+    t.index ["user_id", "cycle_id"], name: "index_reading_log_entries_on_user_id_and_cycle_id"
+    t.index ["user_id"], name: "index_reading_log_entries_on_user_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "ip_address"
@@ -146,6 +160,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_090000) do
   add_foreign_key "nominations", "books"
   add_foreign_key "nominations", "cycles"
   add_foreign_key "nominations", "users"
+  add_foreign_key "reading_log_entries", "cycles"
+  add_foreign_key "reading_log_entries", "users"
   add_foreign_key "sessions", "users"
   add_foreign_key "votes", "cycles"
   add_foreign_key "votes", "nominations"

--- a/test/controllers/reading_log_entries_controller_test.rb
+++ b/test/controllers/reading_log_entries_controller_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class ReadingLogEntriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @member = users(:one)
+    @club_member = users(:two)
+    @non_member = users(:three)
+
+    @club = Club.create!(
+      name: "Reading club #{SecureRandom.hex(4)}",
+      description: "Club for reading log tests",
+      created_by: @member
+    )
+    @club.memberships.create!(user: @member, role: :owner)
+    @club.memberships.create!(user: @club_member, role: :member)
+
+    @cycle = @club.cycles.create!(state: :voting)
+    winning_nomination = @cycle.nominations.create!(user: @member, book: books(:the_hobbit))
+    @cycle.update!(winning_nomination: winning_nomination, state: :reading)
+
+    @nominating_club = Club.create!(
+      name: "Nominating club #{SecureRandom.hex(4)}",
+      description: "Club for invalid state tests",
+      created_by: @member
+    )
+    @nominating_club.memberships.create!(user: @member, role: :owner)
+    @nominating_cycle = @nominating_club.cycles.create!(state: :nominating)
+  end
+
+  test "member can create reading log entry" do
+    sign_in_as(@club_member)
+
+    assert_difference "ReadingLogEntry.count", 1 do
+      post cycle_reading_log_entries_path(@cycle), params: {
+        reading_log_entry: {
+          state: "started",
+          page_reached: 12,
+          note: "Strong opening chapter"
+        }
+      }
+    end
+
+    assert_redirected_to @club
+    entry = ReadingLogEntry.last
+    assert_equal @club_member, entry.user
+    assert_equal @cycle, entry.cycle
+    assert_equal "started", entry.state
+    assert_equal 12, entry.page_reached
+    assert_equal "Strong opening chapter", entry.note
+  end
+
+  test "creation is rejected when cycle is not in reading state" do
+    sign_in_as(@member)
+
+    assert_no_difference "ReadingLogEntry.count" do
+      post cycle_reading_log_entries_path(@nominating_cycle), params: {
+        reading_log_entry: {
+          state: "started",
+          page_reached: 10,
+          note: "Should fail"
+        }
+      }
+    end
+
+    assert_redirected_to @nominating_club
+    assert_equal "Reading log is not open for this cycle", flash[:alert]
+  end
+
+  test "non-member gets forbidden" do
+    sign_in_as(@non_member)
+
+    assert_no_difference "ReadingLogEntry.count" do
+      post cycle_reading_log_entries_path(@cycle), params: {
+        reading_log_entry: {
+          state: "started",
+          page_reached: 9,
+          note: "Should not be allowed"
+        }
+      }
+    end
+
+    assert_response :forbidden
+  end
+
+  test "page reached cannot exceed winning book page count" do
+    sign_in_as(@member)
+
+    assert_no_difference "ReadingLogEntry.count" do
+      post cycle_reading_log_entries_path(@cycle), params: {
+        reading_log_entry: {
+          state: "progressed",
+          page_reached: 999,
+          note: "Past end"
+        }
+      }
+    end
+
+    assert_redirected_to @club
+    assert_equal "Page reached cannot be greater than total pages (366)", flash[:alert]
+  end
+end


### PR DESCRIPTION
Add immutable reading log entries for cycles in the reading state.

- Create reading_log_entries table with user, cycle, state, page_reached, note, and timestamps
- Add ReadingLogEntry model with explicit string enum states: started, progressed, finished
- Add validations:
  - cycle must be in reading state
  - page_reached must be a positive integer when present
  - page_reached cannot exceed winning book page_count when available
- Add associations:
  - cycle has_many reading_log_entries, dependent: :destroy
  - user has_many reading_log_entries, dependent: :destroy
- Add ReadingLogEntriesController#create with:
  - membership-scoped cycle lookup
  - member-only access (forbidden when not in scope)
  - html + turbo_stream responses
- Add nested route under cycles (shallow, create-only)
- Add reading UI partials for:
  - reading state block
  - turbo-frame form + list refresh
  - entry row rendering
- Render reading state section in club show when current cycle is reading
- Fix turbo-frame behavior:
  - avoid duplicate book/details rendering on submit
  - clear form after successful create
- Add request tests for:
  - successful creation
  - rejection when cycle is not reading
  - non-member forbidden
  - page_reached vs page_count validation

Note: Reading log entries are append-only/immutable; transition methods were intentionally removed from scope.

Closes #39 
Closes #40