### PR TITLE
docs: backfill ADRs based on JOURNAL

### DIFF
--- a/docs/decisions/007-book-lookup-result-return-type.md
+++ b/docs/decisions/007-book-lookup-result-return-type.md
@@ -1,0 +1,50 @@
+# ADR-007 — BookLookupService::Result as a Data class rather than Struct
+
+Status: Accepted
+Date: 2026-04-20
+
+## Context
+
+`BookLookupService` needs a return type for search results and ISBN lookups.
+The return type is used in both the web search results partial and the mobile
+barcode scan flow, so it needs to be consistent and safe to pass around.
+
+Two built-in Ruby options were considered:
+
+- **`Struct`** — familiar, lightweight, but mutable by default and uses
+  positional arguments unless keyword_init is set explicitly
+- **`Data`** — introduced in Ruby 3.2, immutable by design, keyword arguments
+  only, value-equality semantics
+
+## Decision
+
+Use `Data` for `BookLookupService::Result`.
+
+`Data` is immutable, which is appropriate for a read-only value object
+representing an external API response. Keyword arguments reduce the risk of
+positional argument errors when the result shape changes. `Struct` offered no
+advantage at this scope.
+
+The class is defined as a nested constant (`BookLookupService::Result`) to
+keep it co-located with the service that produces it.
+
+Connection is injected via keyword argument on the service itself for
+testability without monkey-patching.
+
+## Alternatives considered
+
+- **`Struct`** — rejected: mutable by default; no meaningful advantage over
+  `Data` for a read-only result type.
+- **Dedicated plain Ruby class** — would add boilerplate (`attr_reader`,
+  `initialize`, `==`) without benefit at this scope.
+- **Hash** — rejected: no type boundary, no defined shape, harder to test
+  against.
+
+## Consequences
+
+- `BookLookupService::Result` is immutable — callers cannot modify returned
+  results, which is the correct behaviour for an API cache.
+- The `cover_image_url` method is defined on both `Result` and `Book` with
+  the same interface, so the `_results` partial works with both types without
+  type-checking.
+- Ruby 3.2+ required — already satisfied by the Ruby 3.4.9 pin in ADR-001.

--- a/docs/decisions/008-presenter-layer-introduction.md
+++ b/docs/decisions/008-presenter-layer-introduction.md
@@ -1,0 +1,53 @@
+# ADR-009 — Presenter layer for view logic
+
+Status: Accepted
+Date: 2026-04-21
+
+## Context
+
+The voting UI requires per-nomination logic that depends on both the
+nomination record and the current user: whether the user has voted, which
+nomination they voted for, and whether the vote button should be disabled.
+This logic needs to live somewhere.
+
+Three options were considered:
+
+- **Helpers** — stateless functions in a module; no natural home for
+  per-object state like current_user context
+- **Decorators via a gem (Draper)** — adds a dependency; the pattern it
+  provides can be replicated with a small base class at this scope
+- **Plain presenter objects** — a base class with `delegate_missing_to :record`
+  provides transparent delegation to the underlying model; no gem required
+
+## Decision
+
+Introduce a presenter layer with an `ApplicationPresenter` base class.
+
+`ApplicationPresenter` uses `delegate_missing_to :record` so presenters
+are transparent wrappers — methods not defined on the presenter delegate
+to the model automatically. Presenters live in `app/presenters/`.
+Instantiated in views via `ApplicationHelper#present(record, current_user:)`.
+
+`NominationPresenter` is the first concrete presenter, encapsulating vote
+button logic and disabled state.
+
+## Alternatives considered
+
+- **Helpers** — rejected: stateless; awkward to pass `current_user` context
+  through multiple helper calls without polluting the helper module with
+  state.
+- **Draper** — rejected: adds a gem dependency that the base class approach
+  fully replaces at this scope. Draper would be a reasonable choice if the
+  pattern grew significantly.
+- **Logic in the view or partial** — rejected: tested logic in a presenter
+  is preferable to untested conditionals in ERB.
+
+## Consequences
+
+- View logic with user context now has a consistent, testable home.
+- `delegate_missing_to :record` means presenters are safe to pass to partials
+  that expect the underlying model — no interface mismatch.
+- The pattern is lightweight enough to extend without a gem; revisit Draper
+  only if presenter count or complexity grows significantly.
+- New per-object view logic with user context should follow this pattern
+  rather than reaching for helpers or inline conditionals.

--- a/docs/decisions/009-tie-break-logic.md
+++ b/docs/decisions/009-tie-break-logic.md
@@ -1,0 +1,49 @@
+# ADR-009 — Tie-break: random selection among tied nominations
+
+Status: Accepted
+Date: 2026-04-22
+
+## Context
+
+When voting closes, `Cycle#close_voting_and_select_winner!` must declare a
+winner. If two or more nominations share the highest vote count, a tie-break
+rule is needed.
+
+Two options were considered:
+
+- **Earliest nomination wins** — deterministic; rewards members who nominated
+  early; original planned approach
+- **Random selection** — non-deterministic per run; treats all tied
+  nominations equally regardless of when they were submitted
+
+## Decision
+
+Use random selection (`Array#sample`) among tied nominations.
+
+Earliest-nomination-wins was the original plan but was reconsidered before
+implementation. Rewarding early nomination creates a mild incentive to
+nominate quickly rather than thoughtfully, which cuts against the app's
+character. Random selection is simpler to reason about and treats a tie as
+what it is: the group genuinely couldn't decide.
+
+The return value of `close_voting_and_select_winner!` signals whether the
+outcome was `:tied` or `:clear_winner`, giving the controller the option to
+surface this to users if needed.
+
+## Alternatives considered
+
+- **Earliest nomination wins** — rejected: deterministic but creates a
+  perverse incentive; inconsistent with the app's intent.
+- **Club owner breaks the tie manually** — rejected: adds UI and state
+  complexity not justified at this scope; defers a decision the system can
+  make cleanly.
+
+## Consequences
+
+- Tie outcomes are non-deterministic — the same tied vote will not always
+  produce the same winner. This is intentional.
+- `close_voting_and_select_winner!` returns `:tied` or `:clear_winner` —
+  callers can use this to show a "it was a tie!" message if desired.
+  Not yet surfaced in the UI; available when needed.
+- `Array#sample` uses Ruby's default PRNG — not cryptographically random,
+  which is appropriate for this use case.

--- a/docs/decisions/010-turbo-stream-patterns.md
+++ b/docs/decisions/010-turbo-stream-patterns.md
@@ -1,0 +1,59 @@
+# ADR-010 — Vote tally broadcasts dispatched from the controller; state-change broadcasts via model callback
+
+Status: Accepted
+Date: 2026-04-23
+
+## Context
+
+NextChapter uses Turbo Streams to push real-time updates to connected club
+members. Three broadcast patterns are now in use across the codebase:
+
+1. **Nomination broadcasts** — `after_create_commit` / `after_update_commit`
+   model callbacks on `Nomination`
+2. **Vote tally broadcasts** — `BroadcastVoteTallyJob` dispatched explicitly
+   from `VotesController`
+3. **Cycle state-change broadcasts** — `after_update` callback on `Cycle`,
+   firing `Turbo::StreamsChannel.broadcast_refresh_to` when state changes
+
+The asymmetry between patterns 1 and 2 requires explanation.
+
+## Decision
+
+**Nomination broadcasts use model callbacks.** The create-and-broadcast flow
+is simple and synchronous; the callback fires reliably in this context.
+
+**Vote tally broadcasts use an explicit job dispatched from the controller.**
+`after_create_commit` on `Vote` was implemented first but proved unreliable:
+the callback fired inside a `SolidCable::TrimJob` thread in the Solid
+Cable/SQLite threading context and was silently swallowed. Moving the
+broadcast to an explicit job dispatched from the controller resolved this.
+The controller is the right place to own the side-effect in any case — the
+broadcast is a consequence of the HTTP action, not an intrinsic property of
+the Vote model.
+
+**Cycle state-change broadcasts use a model callback** (`after_update` scoped
+to `saved_change_to_state?`). This is a page-level `broadcast_refresh_to`
+rather than a partial update, so it does not share the threading issue that
+affected Vote. The Cycle model is the canonical owner of state, making it the
+natural place for this side-effect.
+
+## Alternatives considered
+
+- **Model callback for vote tallies** — tried and rejected; silently failed
+  in the Solid Cable/SQLite threading context.
+- **Controller dispatch for all broadcasts** — consistent but would require
+  moving nomination and cycle broadcasts out of models where they sit cleanly.
+- **Single broadcast pattern for everything** — not pursued; the three use
+  cases have meaningfully different characteristics (partial update vs page
+  refresh, model-owned state vs controller-owned action).
+
+## Consequences
+
+- The asymmetry is intentional and documented here. Future broadcast work
+  should default to model callbacks for model-owned state changes and
+  controller dispatch for action-driven side-effects.
+- The Solid Cable/SQLite threading issue may not affect other callback types
+  — nominations are unaffected. The root cause is specific to the Vote
+  create flow in that threading context.
+- `BroadcastVoteTallyJob` is the established pattern for controller-dispatched
+  broadcasts; new jobs of this type should follow the same structure.


### PR DESCRIPTION
On review of the current JOURNAL.md, it became clear I'd missed logging a couple of ADR-worthy decisions.

This catches us up, setting in good stead for today's polish-focused work.