### PR TITLE
feat(seed): add featured books and cover image collage for landing page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,5 +3,8 @@ class HomeController < ApplicationController
 
   def index
     redirect_to clubs_path if authenticated?
+    @collage_books = Book.where(featured: true)
+                         .order(Arel.sql("featured_index IS NULL, featured_index ASC, id ASC"))
+                         .with_attached_cover_image
   end
 end

--- a/app/views/books/_results.html.erb
+++ b/app/views/books/_results.html.erb
@@ -15,7 +15,7 @@
       </div>
       <div class="nc-search-result-item__content">
         <h3 class="nc-nomination-item__title"><%= book.title %></h3>
-        <p class="nc-nomination-item__author"><%= book.authors.presence || "Author unknown" %></p>
+        <p class="nc-nomination-item__author"><%= book.authors.presence || "Author unknown" %> - <%= book.isbn %></p>
         <% if book.page_count.presence&.positive? %>
           <p class="nc-nomination-item__meta"><%= book.page_count %> pages</p>
         <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,20 +23,34 @@
     <div class="nc-landing-hero__visual" aria-hidden="true">
       <div class="nc-landing-collage">
         <div class="nc-landing-collage__column nc-landing-collage__column--1">
-          <div class="nc-landing-collage__block bg-primary"></div>
-          <div class="nc-landing-collage__block bg-surface-container-highest"></div>
-          <div class="nc-landing-collage__block bg-primary-container"></div>
+          <% [0, 1, 2].each do |i| %>
+            <% book = @collage_books[i] %>
+            <% if book&.cover_image_url %>
+              <div class="nc-landing-collage__block" style="background-image: url('<%= book.cover_image_url %>'); background-size: cover; background-position: center;"></div>
+            <% else %>
+              <div class="nc-landing-collage__block <%= %w[bg-primary bg-surface-container-highest bg-primary-container][i] %>"></div>
+            <% end %>
+          <% end %>
         </div>
         <div class="nc-landing-collage__column nc-landing-collage__column--2">
-          <div class="nc-landing-collage__block bg-tertiary"></div>
-          <div class="nc-landing-collage__block bg-primary"></div>
-          <div class="nc-landing-collage__block bg-tertiary-container"></div>
-          <div class="nc-landing-collage__block bg-outline-variant"></div>
+          <% [3, 4, 5].each_with_index do |book_idx, i| %>
+            <% book = @collage_books[book_idx] %>
+            <% if book&.cover_image_url %>
+              <div class="nc-landing-collage__block" style="background-image: url('<%= book.cover_image_url %>'); background-size: cover; background-position: center;"></div>
+            <% else %>
+              <div class="nc-landing-collage__block <%= %w[bg-tertiary bg-primary bg-tertiary-container][i] %>"></div>
+            <% end %>
+          <% end %>
         </div>
         <div class="nc-landing-collage__column nc-landing-collage__column--3">
-          <div class="nc-landing-collage__block bg-tertiary"></div>
-          <div class="nc-landing-collage__block bg-surface-container-high"></div>
-          <div class="nc-landing-collage__block bg-primary"></div>
+          <% [6, 7, 8].each_with_index do |book_idx, i| %>
+            <% book = @collage_books[book_idx] %>
+            <% if book&.cover_image_url %>
+              <div class="nc-landing-collage__block" style="background-image: url('<%= book.cover_image_url %>'); background-size: cover; background-position: center;"></div>
+            <% else %>
+              <div class="nc-landing-collage__block <%= %w[bg-tertiary bg-surface-container-high bg-primary][i] %>"></div>
+            <% end %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/db/migrate/20260423200000_add_featured_to_books.rb
+++ b/db/migrate/20260423200000_add_featured_to_books.rb
@@ -1,0 +1,5 @@
+class AddFeaturedToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :featured, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260424000000_add_featured_index_to_books.rb
+++ b/db/migrate/20260424000000_add_featured_index_to_books.rb
@@ -1,0 +1,5 @@
+class AddFeaturedIndexToBooks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :books, :featured_index, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_23_175045) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_000000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -44,6 +44,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_23_175045) do
     t.string "cover_url"
     t.datetime "created_at", null: false
     t.text "description"
+    t.boolean "featured", default: false, null: false
+    t.integer "featured_index"
     t.string "google_books_id"
     t.string "isbn"
     t.integer "page_count"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,49 +2,53 @@
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
-puts "Seeding database..."
+require_relative "seeds/collage_books"
 
-# Users
-alice = User.find_or_create_by!(email_address: "alice@example.com") do |user|
-  user.name = "Alice Wonderland"
-  user.password = "password123456"
-  user.password_confirmation = "password123456"
+if Rails.env.development?
+  puts "Seeding database..."
+
+  # Users
+  alice = User.find_or_create_by!(email_address: "alice@example.com") do |user|
+    user.name = "Alice Wonderland"
+    user.password = "password123456"
+    user.password_confirmation = "password123456"
+  end
+
+  bob = User.find_or_create_by!(email_address: "bob@example.com") do |user|
+    user.name = "Bob Belcher"
+    user.password = "password123456"
+    user.password_confirmation = "password123456"
+  end
+
+  puts "Created #{User.count} users"
+
+  # Club
+  club = Club.find_or_create_by!(name: "The Knights Radiant") do |c|
+    c.description = "A friendly book club for Stormlight Archive fanatics."
+    c.created_by = alice
+  end
+
+  puts "Created #{Club.count} club(s)"
+
+  # Memberships
+  Membership.find_or_create_by!(user: alice, club: club) do |m|
+    m.role = :owner
+  end
+
+  Membership.find_or_create_by!(user: bob, club: club) do |m|
+    m.role = :member
+  end
+
+  puts "Created #{Membership.count} membership(s)"
+
+  # Cycle
+  unless club.current_cycle
+    club.cycles.create!(state: :nominating)
+  end
+
+  puts "Cycles: #{Cycle.count}"
+
+  # TODO: Seed Nominations and Votes once those models exist (Day 4/5)
+
+  puts "Done."
 end
-
-bob = User.find_or_create_by!(email_address: "bob@example.com") do |user|
-  user.name = "Bob Belcher"
-  user.password = "password123456"
-  user.password_confirmation = "password123456"
-end
-
-puts "Created #{User.count} users"
-
-# Club
-club = Club.find_or_create_by!(name: "The Knights Radiant") do |c|
-  c.description = "A friendly book club for Stormlight Archive fanatics."
-  c.created_by = alice
-end
-
-puts "Created #{Club.count} club(s)"
-
-# Memberships
-Membership.find_or_create_by!(user: alice, club: club) do |m|
-  m.role = :owner
-end
-
-Membership.find_or_create_by!(user: bob, club: club) do |m|
-  m.role = :member
-end
-
-puts "Created #{Membership.count} membership(s)"
-
-# Cycle
-unless club.current_cycle
-  club.cycles.create!(state: :nominating)
-end
-
-puts "Cycles: #{Cycle.count}"
-
-# TODO: Seed Nominations and Votes once those models exist (Day 4/5)
-
-puts "Done."

--- a/db/seeds/collage_books.rb
+++ b/db/seeds/collage_books.rb
@@ -1,0 +1,50 @@
+COLLAGE_ISBNS = [
+  { isbn: "9780399563669", index: 0 },
+  { isbn: "9781534312326", index: 1 },
+  { isbn: "9781786890115", index: 2 },
+  { isbn: "9780575093355", index: 3 },
+  { isbn: "9780316556323", index: 4 },
+  { isbn: "9780330534239", index: 5 },
+  { isbn: "9781399614481", index: 6 },
+  { isbn: "9781607067238", index: 7 },
+  { isbn: "9780385490818", index: 8 }
+].freeze
+
+puts "Seeding collage books..."
+
+COLLAGE_ISBNS.each do |entry|
+  result = BookLookupService.find_by_isbn(entry[:isbn])
+
+  unless result
+    puts "  WARNING: no result from Google Books for ISBN #{entry[:isbn]} — skipping"
+    next
+  end
+
+  book = if result.google_books_id.present?
+    Book.find_by(google_books_id: result.google_books_id)
+  end
+
+  if book
+    book.update!(featured: true, featured_index: entry[:index])
+    puts "  Updated existing book as featured: #{book.title}"
+  else
+    book = Book.create!(
+      google_books_id: result.google_books_id,
+      title: result.title,
+      authors: result.authors,
+      isbn: result.isbn,
+      description: result.description,
+      cover_url: result.cover_url,
+      publisher: result.publisher,
+      published_date: result.published_date,
+      page_count: result.page_count,
+      featured: true,
+      featured_index: entry[:index]
+    )
+    puts "  Created featured book: #{book.title}"
+  end
+
+  CacheCoverImageJob.perform_later(book.id)
+end
+
+puts "Collage books seeded: #{Book.where(featured: true).count} featured book(s)"


### PR DESCRIPTION
Seeds a curated set of 9 books used to populate the book cover collage on the logged-out landing page.

- Add `featured` boolean to `books` (default: false, null: false)
- Add `featured_index` nullable integer to `books` — controls display order in the collage; NULL means unordered and sorts to the end

- New seed file, required unconditionally from db/seeds.rb
- Looks up each book via `BookLookupService.find_by_isbn` using ISBN-13
- Creates the `Book` record if not already present (idempotent via `google_books_id` lookup before create)
- Sets `featured: true` and `featured_index` on create and update
- Enqueues `CacheCoverImageJob` for each book after upsert
- Existing dev-only seed data (users, clubs, memberships, cycles) is now wrapped in `Rails.env.development?`

- `index` assigns `@collage_books`: `Book.where(featured: true) .order(Arel.sql("featured_index IS NULL, featured_index ASC, id ASC")) .with_attached_cover_image`
- `with_attached_cover_image` prevents N+1 queries on the association

- Three-column layout (3 / 3 / 3) now iterates over `@collage_books`
- Each slot renders a `background-image` inline style using `book.cover_image_url` when available
- Falls back to the original colour block placeholder class if the cover image has not yet been cached

Closes #97 

## Demo
<img width="1867" height="1284" alt="583042285-2ed535e7-842a-4d39-a126-93362b13b11a" src="https://github.com/user-attachments/assets/4078c413-7906-4435-9b21-684bdaeebafe" />