### PR TITLE
feat(backend): cycle closing and next-cycle creation

### DIFF
--- a/app/controllers/cycles_controller.rb
+++ b/app/controllers/cycles_controller.rb
@@ -1,6 +1,6 @@
 class CyclesController < ApplicationController
   before_action :set_cycle_and_club
-  before_action :require_club_owner!, only: [ :close_voting, :close_nominations ]
+  before_action :require_club_owner!, only: [ :close_nominations, :close_voting, :complete ]
 
   # Handle errors from invalid state transitions in the cycle model
   # TODO - extract transition logic to service and raise more specific
@@ -21,6 +21,15 @@ class CyclesController < ApplicationController
       "Voting closed. A tie was randomly broken to select the winner." : "Voting closed."
 
     redirect_to @club, notice: message, status: :see_other
+  end
+
+
+  def complete
+    ActiveRecord::Base.transaction do
+      @cycle.complete!
+      @club.cycles.create!(state: :nominating)
+    end
+    redirect_to @club, notice: "Reading cycle complete. Time to nominate again.", status: :see_other
   end
 
   private

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -95,6 +95,13 @@
             cycle: @cycle,
             reading_log_entry: ReadingLogEntry.new,
             reading_log_entries: @cycle.reading_log_entries.where(user: Current.user).order(created_at: :desc) %>
+
+      <% if @is_owner %>
+        <%= button_to "Start New Cycle", complete_cycle_path(@cycle),
+              method: :post,
+              class: "nc-button nc-button--tertiary",
+              data: { turbo_frame: "_top" } %>
+      <% end %>
     <% end %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       member do
         patch :close_voting
         patch :close_nominations
+        post :complete
       end
 
       resources :nominations, only: [ :create ], shallow: true do

--- a/test/controllers/cycles_controller_test.rb
+++ b/test/controllers/cycles_controller_test.rb
@@ -6,6 +6,7 @@ class CyclesControllerTest < ActionDispatch::IntegrationTest
     @non_owner = users(:two)
     @nominating_cycle = cycles(:nominating)
     @voting_cycle = cycles(:voting)
+    @reading_cycle = cycles(:reading)
   end
 
   test "owner can close nominations" do
@@ -110,5 +111,37 @@ class CyclesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Cannot close voting without any votes", flash[:alert]
     assert_equal "voting", @voting_cycle.reload.state
     assert_nil @voting_cycle.winning_nomination
+  end
+
+  test "owner can complete a reading cycle" do
+    sign_in_as(@owner)
+
+    post complete_cycle_path(@reading_cycle)
+
+    assert_redirected_to @reading_cycle.club
+    assert_equal "Reading cycle complete. Time to nominate again.", flash[:notice]
+
+    @reading_cycle.reload
+    assert_equal "complete", @reading_cycle.state
+    assert @reading_cycle.club.cycles.where(state: :nominating).exists?
+  end
+
+  test "non-owner gets 403 when trying to complete a cycle" do
+    sign_in_as(@non_owner)
+
+    post complete_cycle_path(@reading_cycle)
+
+    assert_response :forbidden
+    assert_equal "reading", @reading_cycle.reload.state
+  end
+
+  test "complete is rejected when cycle is not in reading state" do
+    sign_in_as(@owner)
+
+    post complete_cycle_path(@nominating_cycle)
+
+    assert_redirected_to @nominating_cycle.club
+    assert_equal "Cannot complete from nominating", flash[:alert]
+    assert_equal "nominating", @nominating_cycle.reload.state
   end
 end

--- a/test/fixtures/clubs.yml
+++ b/test/fixtures/clubs.yml
@@ -14,3 +14,8 @@ three:
   name: ClubThree
   description: ClubThree description
   created_by: one
+
+four:
+  name: ClubFour
+  description: ClubFour description
+  created_by: one

--- a/test/fixtures/cycles.yml
+++ b/test/fixtures/cycles.yml
@@ -11,3 +11,7 @@ complete:
 voting:
   club: three
   state: voting
+
+reading:
+  club: four
+  state: reading

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -22,3 +22,13 @@ club_three_member:
   user: two
   club: three
   role: member
+
+club_four_owner:
+  user: one
+  club: four
+  role: owner
+
+club_four_member:
+  user: two
+  club: four
+  role: member


### PR DESCRIPTION
Add a `complete` action to CyclesController that transitions the current cycle to the `complete` state and atomically creates a new `nominating` cycle for the club, keeping the club continuously active.

- Route: POST member route `complete` on cycles (shallow, nested under clubs)
- Controller: gate `complete` behind `require_club_owner!`; wrap `cycle.complete!` + `club.cycles.create!(state: :nominating)` in a transaction; redirect to club with success notice on success, or let the existing `rescue_from RuntimeError` handler redirect with an alert on invalid state transitions
- View: owner-only "Start New Cycle" button in the `reading?` block of clubs/show, following the same `nc-button--tertiary` + `turbo_frame: "_top"` pattern as Close Nominations and Close Voting
- Tests: 3 new request tests covering owner success (cycle marked complete, new nominating cycle created), non-owner 403, and wrong-state rejection; backed by a new `reading` cycle fixture with supporting club and membership fixtures

Closes #91 