### PR TITLE
fix(frontend): responsive design amends

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -313,3 +313,22 @@ a {
 .nc-book-cover-placeholder--lg {
 	width: 96px;
 }
+
+/* === Mobile sidebar — top nav bar on small screens === */
+
+@media (max-width: 900px) {
+	.nc-sidebar {
+		width: 100%;
+		min-height: auto;
+		padding: 10px 16px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: wrap;
+		gap: 4px 8px;
+	}
+
+	.nc-brand {
+		margin-bottom: 0;
+	}
+}

--- a/app/assets/stylesheets/auth.css
+++ b/app/assets/stylesheets/auth.css
@@ -146,3 +146,15 @@
 		padding: var(--spacing-6);
 	}
 }
+
+@media (max-width: 430px) {
+	.nc-auth-container {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
+	.nc-auth-card {
+		padding: var(--spacing-4);
+		border-radius: var(--radius-sm);
+	}
+}

--- a/app/assets/stylesheets/club_detail.css
+++ b/app/assets/stylesheets/club_detail.css
@@ -322,11 +322,6 @@
 	.nc-search-result-item,
 	.nc-nomination-item {
 		align-items: flex-start;
-	}
-
-	.nc-search-result-item,
-	.nc-nomination-item,
-	.nc-current-book-callout {
 		flex-direction: column;
 	}
 

--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -1,8 +1,8 @@
 /* Landing page — styles scoped to nc-landing-* */
 
 .nc-landing {
-	margin: -32px -24px 0;
-	background: var(--color-surface);
+  margin: -32px -24px 0;
+  background: var(--color-surface);
 }
 
 .nc-landing-header,
@@ -10,318 +10,332 @@
 .nc-landing-quote,
 .nc-landing-footer-cta,
 .nc-landing-footer {
-	padding-left: 24px;
-	padding-right: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 .nc-landing-header {
-	padding-top: 20px;
-	padding-bottom: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
 }
 
 .nc-landing-header__logo {
-	display: flex;
-	align-items: center;
-	gap: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .nc-landing-hero__inner,
 .nc-landing-section__inner,
 .nc-landing-quote__inner {
-	max-width: 1200px;
-	margin: 0 auto;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .nc-landing-wordmark,
 .nc-wordmark-text {
-	margin: 0;
-	font-family: "Newsreader", Georgia, serif;
-	font-size: 1.25rem;
-	line-height: 1.2;
-	letter-spacing: -0.01em;
+  margin: 0;
+  font-family: "Newsreader", Georgia, serif;
+  font-size: 1.25rem;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
   margin-bottom: -6px;
 }
 
 .nc-landing-link {
-	text-decoration: none;
-	font-size: 0.75rem;
-	font-weight: 500;
-	letter-spacing: 0.1em;
-	text-transform: uppercase;
+  text-decoration: none;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
 }
 
 .nc-landing-button {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	padding: 12px 28px;
-	border-radius: var(--radius-sm);
-	font-size: 0.75rem;
-	font-weight: 500;
-	letter-spacing: 0.1em;
-	text-transform: uppercase;
-	text-decoration: none;
-	line-height: 1.2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 28px;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-decoration: none;
+  line-height: 1.2;
 }
 
 .nc-landing-button--primary {
-	background: var(--color-primary);
-	color: var(--color-on-primary);
+  background: var(--color-primary);
+  color: var(--color-on-primary);
 }
 
 .nc-landing-button--ghost {
-	background: var(--color-surface-container);
-	color: var(--color-on-surface);
-	box-shadow: inset 0 0 0 1px var(--color-outline-variant);
+  background: var(--color-surface-container);
+  color: var(--color-on-surface);
+  box-shadow: inset 0 0 0 1px var(--color-outline-variant);
 }
 
 .nc-landing-hero {
-	height: 594px;
-	position: relative;
-	overflow: hidden;
-	align-content: center;
-	--content-offset: max(24px, calc((100vw - 1200px) / 2));
+  height: 594px;
+  position: relative;
+  overflow: hidden;
+  align-content: center;
+  --content-offset: max(24px, calc((100vw - 1200px) / 2));
 }
 
 .nc-landing-hero__inner {
-	display: flex;
-	gap: 40px;
-	padding: 56px 24px 96px;
+  display: flex;
+  gap: 40px;
+  padding: 56px 24px 96px;
 }
 
 .nc-landing-hero__visual {
-	position: absolute;
-	top: 0;
-	right: var(--content-offset);
-	display: flex;
-	justify-content: flex-end;
-	overflow: visible;
+  position: absolute;
+  top: 0;
+  right: var(--content-offset);
+  display: flex;
+  justify-content: flex-end;
+  overflow: visible;
 }
 
 .nc-landing-hero__content {
-	max-width: 640px;
+  max-width: 640px;
 }
 
 .nc-landing-display {
-	letter-spacing: -0.01em;
-	margin-bottom: 32px;
+  letter-spacing: -0.01em;
+  margin-bottom: 32px;
 }
 
 .nc-landing-body-lg {
-	margin: 0 0 32px;
-	font-size: 1rem;
-	line-height: 1.6;
-	max-width: 520px;
+  margin: 0 0 32px;
+  font-size: 1rem;
+  line-height: 1.6;
+  max-width: 520px;
 }
 
 .nc-landing-hero__actions {
-	display: flex;
-	align-items: center;
-	gap: 16px;
-	flex-wrap: wrap;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
 }
 
 .nc-landing-collage {
-	display: grid;
-	grid-template-columns: 130px 130px 130px;
-	gap: 8px;
-	height: 100%;
-	align-items: stretch;
+  display: grid;
+  grid-template-columns: 130px 130px 130px;
+  gap: 8px;
+  height: 100%;
+  align-items: stretch;
 }
 
 .nc-landing-collage__column {
-	display: flex;
-	flex-direction: column;
-	gap: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .nc-landing-collage__column--1 {
-	margin-top: 60px;
-	align-items: flex-start;
+  margin-top: 60px;
+  align-items: flex-start;
 }
 
 .nc-landing-collage__column--2 {
-	margin-top: 0;
-	align-items: center;
-	justify-content: stretch;
+  margin-top: 0;
+  align-items: center;
+  justify-content: stretch;
 }
 
 .nc-landing-collage__column--3 {
-	margin-top: -60px;
-	align-items: flex-end;
-	justify-content: flex-start;
+  margin-top: -60px;
+  align-items: flex-end;
+  justify-content: flex-start;
 }
 
 .nc-landing-collage__block {
-	width: 130px;
-	height: 195px;
-	border-radius: var(--radius-sm);
-	flex-shrink: 0;
+  width: 130px;
+  height: 195px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
 }
 
 .nc-landing-features {
-	background: var(--color-surface-container-low);
-	padding-top: 80px;
-	padding-bottom: 80px;
+  background: var(--color-surface-container-low);
+  padding-top: 80px;
+  padding-bottom: 80px;
 }
 
 .nc-landing-feature-card {
-	background: var(--color-surface-container-lowest);
-	border-radius: var(--radius);
-	padding: 24px;
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
+  background: var(--color-surface-container-lowest);
+  border-radius: var(--radius);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .nc-landing-feature-icon {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 40px;
-	height: 40px;
-	border-radius: var(--radius-sm);
-	background: var(--color-surface-container-high);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-container-high);
 }
 
 .nc-landing-feature-icon svg {
-	width: 20px;
-	height: 20px;
+  width: 20px;
+  height: 20px;
 }
 
 .nc-landing-body-sm {
-	margin: 0;
-	font-size: 0.875rem;
-	line-height: 1.6;
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
 }
 
 .nc-landing-quote {
-	padding-top: 96px;
-	padding-bottom: 96px;
+  padding-top: 96px;
+  padding-bottom: 96px;
 }
 
 .nc-landing-quote__inner {
-	max-width: 860px;
-	text-align: center;
+  max-width: 860px;
+  text-align: center;
 }
 
 .nc-landing-quote__text {
-	margin: 0 0 24px;
-	font-family: "Newsreader", Georgia, serif;
-	font-size: 2.25rem;
-	font-style: italic;
-	font-weight: 400;
-	line-height: 1.3;
+  margin: 0 0 24px;
+  font-family: "Newsreader", Georgia, serif;
+  font-size: 2.25rem;
+  font-style: italic;
+  font-weight: 400;
+  line-height: 1.3;
 }
 
 .nc-landing-quote__attribution {
-	margin: 0;
-	font-size: 0.75rem;
-	font-weight: 500;
-	text-transform: uppercase;
-	letter-spacing: 0.1em;
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
 
 .nc-landing-footer-cta {
-	background: var(--color-surface-container-high);
-	padding-top: 96px;
-	padding-bottom: 96px;
+  background: var(--color-surface-container-high);
+  padding-top: 96px;
+  padding-bottom: 96px;
 }
 
 .nc-landing-footer {
-	padding-top: 32px;
-	padding-bottom: 32px;
+  padding-top: 32px;
+  padding-bottom: 32px;
 }
 
 .nc-landing-footer__link {
-	text-decoration: none;
-	font-size: 0.75rem;
-	text-transform: uppercase;
-	letter-spacing: 0.1em;
+  text-decoration: none;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
 
 .nc-landing-footer__copy {
-	margin: 0;
-	font-size: 0.75rem;
-	text-align: right;
+  margin: 0;
+  font-size: 0.75rem;
+  text-align: right;
 }
 
 @media (max-width: 1080px) {
-	.nc-landing-hero {
-		padding-top: 48px;
-		padding-bottom: 72px;
-	}
+  .nc-landing-display {
+    font-size: 2.75rem;
+  }
 
-	.nc-landing-hero__visual {
-		display: none;
-	}
+  .nc-landing-hero__visual {
+    display: none;
+  }
 
-	.nc-landing-display {
-		font-size: 2.75rem;
-	}
-
-	.nc-landing-footer__copy {
-		text-align: center;
-	}
+  .nc-landing-footer__copy {
+    text-align: center;
+  }
 }
 
 @media (max-width: 700px) {
-	.nc-landing {
-		margin: -32px -24px 0;
-	}
+  .nc-landing {
+    margin: -32px -24px 0;
+  }
 
-	.nc-landing-nav,
-	.nc-landing-features,
-	.nc-landing-quote,
-	.nc-landing-footer-cta,
-	.nc-landing-footer {
-		padding-left: 16px;
-		padding-right: 16px;
-	}
+  .nc-landing-nav,
+  .nc-landing-features,
+  .nc-landing-quote,
+  .nc-landing-footer-cta,
+  .nc-landing-footer {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
 
-	.nc-landing-nav {
-		padding-top: 16px;
-		padding-bottom: 16px;
-	}
+  .nc-landing-nav {
+    padding-top: 16px;
+    padding-bottom: 16px;
+  }
 
-	/* Hero: remove fixed height so buttons are never clipped */
-	.nc-landing-hero {
-		height: auto;
-		overflow: visible;
-		align-content: initial;
-	}
+  /* Hero: remove fixed height so buttons are never clipped */
+  .nc-landing-hero {
+    height: auto;
+    overflow: visible;
+    align-content: initial;
+  }
 
-	/* Tighten hero padding using spacing tokens */
-	.nc-landing-hero__inner {
-		padding-top: var(--spacing-8);
-		padding-bottom: var(--spacing-12);
-	}
+  /* Tighten hero padding using spacing tokens */
+  .nc-landing-hero__inner {
+    padding-top: var(--spacing-8);
+    padding-bottom: var(--spacing-12);
+  }
 
-	/* Scale display heading down to the intended mobile size */
-	.nc-landing-hero .nc-type-display-lg {
-		font-size: 2.25rem;
-	}
+  /* Scale display heading down to the intended mobile size */
+  .nc-landing-hero .nc-type-display-lg {
+    font-size: 2.25rem;
+  }
 
-	.nc-landing-display {
-		font-size: 2.25rem;
-		margin-bottom: 24px;
-	}
+  .nc-landing-display {
+    font-size: 2.25rem;
+    margin-bottom: 24px;
+  }
 
-	.nc-landing-body-lg {
-		margin-bottom: 24px;
-	}
+  .nc-landing-body-lg {
+    margin-bottom: 24px;
+  }
 
-	.nc-landing-quote {
-		padding-top: 72px;
-		padding-bottom: 72px;
-	}
+  .nc-landing-quote {
+    padding-top: 72px;
+    padding-bottom: 72px;
+  }
 
-	.nc-landing-quote__text {
-		font-size: 1.75rem;
-	}
+  .nc-landing-quote__text {
+    font-size: 1.75rem;
+  }
 
-	.nc-landing-footer-cta {
-		padding-top: 72px;
-		padding-bottom: 72px;
-	}
+  .nc-landing-footer-cta {
+    padding-top: 72px;
+    padding-bottom: 72px;
+  }
+}
+
+@media (max-width: 400px) {
+  .nc-landing-hero__visual {
+    display: flex;
+    position: static;
+    height: 535px;
+    overflow: hidden;
+    justify-content: center;
+  }
+
+  .nc-landing-collage__column--1,
+  .nc-landing-collage__column--3 {
+    margin-top: 0;
+  }
+
+  .nc-landing-collage__column--2 {
+    margin-top: calc(var(--spacing-15) * -1);
+  }
 }

--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -284,6 +284,24 @@
 		padding-bottom: 16px;
 	}
 
+	/* Hero: remove fixed height so buttons are never clipped */
+	.nc-landing-hero {
+		height: auto;
+		overflow: visible;
+		align-content: initial;
+	}
+
+	/* Tighten hero padding using spacing tokens */
+	.nc-landing-hero__inner {
+		padding-top: var(--spacing-8);
+		padding-bottom: var(--spacing-12);
+	}
+
+	/* Scale display heading down to the intended mobile size */
+	.nc-landing-hero .nc-type-display-lg {
+		font-size: 2.25rem;
+	}
+
 	.nc-landing-display {
 		font-size: 2.25rem;
 		margin-bottom: 24px;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -95,8 +95,8 @@
 
   <section class="nc-landing-quote">
     <div class="nc-landing-quote__inner">
-      <blockquote class="nc-landing-quote__text">"NextChapter isn't about counting books; it's about the quality of the conversations that happen between the pages."</blockquote>
-      <p class="nc-landing-quote__attribution">- The Curated Folio Journal</p>
+      <blockquote class="nc-landing-quote__text">“Reading is a conversation. All books talk. But a good book listens as well.”</blockquote>
+      <p class="nc-landing-quote__attribution">— Mark Haddon</p>
     </div>
   </section>
 


### PR DESCRIPTION
- Sidebar collapses to a full-width horizontal top bar at ≤900px; brand and nav links sit on the same row instead of a narrow fixed-height column
- Auth forms: zero out nc-auth-container horizontal padding at ≤430px so inputs are not double-padded against the main wrapper
- Landing hero: remove fixed height (594px) and overflow:hidden at ≤700px so buttons are never clipped by the container; reduce top padding using spacing tokens; scale display heading to 2.25rem
- Club reading panel: keep nc-current-book-callout as flex-row on mobile so cover image stays left and text copy sits to its right